### PR TITLE
Enhance post management with category selection and localization updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 4f595868f95c63849653446e5ab7a96f191974d3
+  revision: 430cff888c248eb45258c74953226edd3b4bae50
   branch: main
   specs:
     actioncable (8.1.0.alpha)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -49,9 +49,12 @@ class PostsController < ApplicationController
     authorize Post
 
     @post = Post.new
-    @post.category_id = params[:category_id] if params[:category_id].present?
 
     @categories = Current.organization.categories.order(:name)
+
+    if params[:category_id].present?
+      @post.category = @categories.find_by(id: params[:category_id])
+    end
   end
 
   # GET /posts/1/edit

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -49,11 +49,16 @@ class PostsController < ApplicationController
     authorize Post
 
     @post = Post.new
+    @post.category_id = params[:category_id] if params[:category_id].present?
+
+    @categories = Current.organization.categories.order(:name)
   end
 
   # GET /posts/1/edit
   def edit
     authorize @post
+
+    @categories = Current.organization.categories.order(:name)
   end
 
   # POST /posts or /posts.json

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,7 +3,13 @@
 <%= form_with(model: post, class: "grid gap-6") do |form| %>
   <%= render "error_messages", resource: form.object %>
 
-  <%= form.hidden_field :category_id, value: Category.first.id %>
+  <div class="grid gap-3">
+    <%= form.label :category_id, t("category") %>
+    <%= form.select :category_id,
+        options_from_collection_for_select(@categories, :id, :name, post.category_id),
+        { prompt: t("select_category") },
+        { class: "form-select" } %>
+  </div>
 
   <div class="grid gap-3">
     <%= form.label :title %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -16,20 +16,20 @@
         <% end %>
       </div>
       <div class="flex-shrink-0">
-        <%= link_to t("posts.new.title"), new_post_path, class: "btn-primary" %>
+        <%= link_to t("posts.new.title"), new_post_path(category_id: @category&.id), class: "btn-primary" %>
       </div>
     </div>
 
     <div class="mb-6">
-      <!-- Boards/Categories Filter -->
+      <!-- Categories Filter -->
       <div class="flex items-center gap-2">
-        <label class="text-sm font-medium text-muted-foreground"><%= t(".boards_label") %></label>
+        <label class="text-sm font-medium text-muted-foreground"><%= t(".categories_label") %></label>
         <%= render_dropdown_menu(
-          trigger: (@category&.name || t(".all_boards")),
+          trigger: (@category&.name || t(".all_categories")),
           width: "w-48",
           trigger_button_variant: :outline,
           content: capture do %>
-            <%= link_to t(".all_boards"), posts_path(category_id: nil, sort: params[:sort], direction: params[:direction], post_status_id: params[:post_status_id]),
+            <%= link_to t(".all_categories"), posts_path(category_id: nil, sort: params[:sort], direction: params[:direction], post_status_id: params[:post_status_id]),
                 class: "block px-4 py-2 text-sm hover:bg-muted rounded-sm #{'bg-muted' unless @category}" %>
             <% @categories.each do |category| %>
               <%= link_to category.name, posts_path(category_id: category.id, sort: params[:sort], direction: params[:direction], post_status_id: params[:post_status_id]),
@@ -78,7 +78,7 @@
             <%= render_button(
               variant: :default,
               size: :default,
-              href: new_post_path,
+              href: new_post_path(category_id: @category&.id),
               class: "gap-2"
             ) do %>
               <%= inline_svg_tag "icons/plus.svg", class: "h-4 w-4" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,7 @@ en:
         view_notifications: View notifications
   are_you_sure: Are you sure?
   cancel: Cancel
+  category: Category
   changelogs:
     index:
       description: New updates and improvements to %{name}
@@ -166,9 +167,9 @@ en:
       body_placeholder: Add your description here...
       title_placeholder: Add a title
     index:
-      all_boards: All Boards
+      all_categories: All Categories
       all_posts: All Posts
-      boards_label: 'Boards:'
+      categories_label: 'Categories:'
       description: Share your ideas and help us improve our product
       empty_feedback_description: Get started by sharing your first suggestion or idea with the community.
       empty_feedback_title: No feedback yet
@@ -191,6 +192,7 @@ en:
       watch: Watch
     update:
       successfully_updated: Post was successfully updated.
+  select_category: Select a category
   something_went_wrong: Something went wrong, please try again.
   themes:
     dark: Dark

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -16,16 +16,12 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get new" do
-    sign_in_as(users(:shane))
-
     get new_post_url
 
     assert_response :success
   end
 
   test "should create post" do
-    sign_in_as(users(:shane))
-
     assert_difference("Post.count") do
       post posts_url, params: { post: { body: @post.body, title: @post.title, category_id: @post.category_id } }
     end
@@ -40,24 +36,18 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get edit" do
-    sign_in_as(users(:shane))
-
     get edit_post_url(@post)
 
     assert_response :success
   end
 
   test "should update post" do
-    sign_in_as(users(:shane))
-
     patch post_url(@post), params: { post: { body: @post.body, title: @post.title } }
 
     assert_redirected_to post_url(@post)
   end
 
   test "should destroy post" do
-    sign_in_as(users(:shane))
-
     assert_difference("Post.count", -1) do
       delete post_url(@post)
     end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: MyString
-  description: MyText
+  name: Feature Requests
+  description: Feature Requests
   organization: feedbackbin
 
 two:
-  name: MyString
-  description: MyText
+  name: Bug Reports
+  description: Bug Reports
   organization: feedbackbin

--- a/test/system/posts_test.rb
+++ b/test/system/posts_test.rb
@@ -13,7 +13,7 @@ class PostsTest < ApplicationSystemTestCase
     assert_selector "a", text: "New Post"
   end
 
-  # TODO: Fix this test, need UI around Boards
+  # TODO: Fix this test, need UI around Categories
   # test "should create post" do
   #   sign_in(users(:shane).email_address)
 


### PR DESCRIPTION
- Updated the post form to allow category selection from a dropdown instead of a hidden field.
- Added category filtering in the posts index view and updated related labels for clarity.
- Improved localization for category-related strings in the application.
- Updated test fixtures for categories to reflect meaningful names.
- Bumped Rails version in Gemfile.lock for compatibility improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Users can choose a category when creating or editing a post; starting from a category will preselect it.

- Style
  - Replaced “Boards” terminology with “Categories” on the posts page and updated related labels/options.
  - Added translations for “Category” and “Select a category.”
  - Switched the post form to a category dropdown with a prompt.

- Tests
  - Consolidated authentication setup in controller tests.
  - Updated category fixtures with clearer names.
  - Minor comment update in system tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->