### PR TITLE
Refactor organization logo rendering and update usage across views

### DIFF
--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -1,41 +1,14 @@
 # frozen_string_literal: true
 
 module OrganizationsHelper
-  def organization_logo(organization, size: :large, **options)
-    size_config = organization_logo_size_config(size)
-    custom_classes = options[:class]
-
-    if organization.logo.attached?
-      image_tag organization.logo,
-        class: "#{size_config[:image_classes]} #{custom_classes}".strip,
-        alt: organization.name
-    else
-      tag.div organization.name[0..1].upcase,
-        class: "#{size_config[:fallback_classes]} #{custom_classes}".strip
-    end
+  def organization_logo(organization, size: :default, **options)
+    render_avatar(
+      src: organization.logo.attached? ? url_for(organization.logo) : nil,
+      alt: organization.name,
+      size: size,
+      fallback: organization.name[0, 2].upcase,
+      shape: :square,
+      **options
+    )
   end
-
-  private
-
-    def organization_logo_size_config(size)
-      case size
-      when :small
-        {
-          image_classes: "h-4 w-4 rounded-sm object-cover flex-shrink-0",
-          fallback_classes: "h-4 w-4 rounded-sm bg-muted text-muted-foreground text-xs font-medium flex items-center justify-center flex-shrink-0"
-        }
-      when :medium
-        {
-          image_classes: "h-5 w-5 rounded-sm object-cover flex-shrink-0",
-          fallback_classes: "h-5 w-5 rounded-sm bg-muted text-muted-foreground text-xs font-medium flex items-center justify-center flex-shrink-0"
-        }
-      when :large
-        {
-          image_classes: "rounded-lg size-12 object-cover",
-          fallback_classes: "size-12 rounded-lg bg-primary text-primary-foreground text-sm font-medium flex items-center justify-center"
-        }
-      else
-        raise ArgumentError, "Unknown logo size: #{size}. Use :small, :medium, or :large"
-      end
-    end
 end

--- a/app/views/application/_organization_switcher.html.erb
+++ b/app/views/application/_organization_switcher.html.erb
@@ -8,7 +8,7 @@
           aria-haspopup="true"
           data-action="click->dropdown#toggle click@window->dropdown#hide">
     <div class="flex items-center gap-3 min-w-0 flex-1">
-      <%= organization_logo(current_organization, size: :medium) %>
+      <%= organization_logo(current_organization) %>
       <span class="text-sm font-medium">
         <%= current_organization.name %>
       </span>
@@ -38,7 +38,7 @@
       </div>
 
       <div class="relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none bg-accent text-accent-foreground gap-2" role="none">
-        <%= organization_logo(current_organization, size: :small) %>
+        <%= organization_logo(current_organization, size: :sm) %>
         <span class="text-sm font-medium">
           <%= current_organization.name %>
         </span>
@@ -52,7 +52,7 @@
               class: "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground gap-2",
               role: "menuitem",
               tabindex: "-1" do %>
-          <%= organization_logo(organization, size: :small) %>
+          <%= organization_logo(organization, size: :sm) %>
           <span class="text-sm font-medium">
             <%= organization.name %>
           </span>

--- a/app/views/organizations/_organization.html.erb
+++ b/app/views/organizations/_organization.html.erb
@@ -2,7 +2,7 @@
   <%= link_to organization_path(organization), class: "block p-6", data: { turbo_frame: "_top" } do %>
     <div class="flex items-center space-x-4">
       <div class="flex-shrink-0">
-        <%= organization_logo(organization) %>
+        <%= organization_logo(organization, size: :lg) %>
       </div>
       <div class="flex-1 min-w-0">
         <h3 class="text-lg font-semibold text-foreground truncate group-hover:text-primary transition-colors">

--- a/test/helpers/organizations_helper_test.rb
+++ b/test/helpers/organizations_helper_test.rb
@@ -3,75 +3,83 @@
 require "test_helper"
 
 class OrganizationsHelperTest < ActionView::TestCase
+  include Components::AvatarHelper
+  include ComponentsHelper
+
   setup do
     @organization = organizations(:feedbackbin)
     @organization_with_logo = organizations(:company)
   end
 
-  test "organization_logo with large size (default)" do
+  test "organization_logo with default size (medium)" do
     logo_html = organization_logo(@organization)
 
-    assert_includes logo_html, 'class="size-12 rounded-lg bg-primary text-primary-foreground text-sm font-medium flex items-center justify-center"'
+    # Avatar component uses size-8 class and square shape (rounded-md)
+    assert_includes logo_html, "size-8"
+    assert_includes logo_html, "rounded-md"
+    # Should contain the fallback initials
     assert_includes logo_html, "FE"
-    assert_no_match(/img/, logo_html) # Should not contain image tag
+    # Should not contain image tag when no logo attached
+    assert_no_match(/<img/, logo_html)
   end
 
-  test "organization_logo with medium size" do
-    logo_html = organization_logo(@organization, size: :medium)
+  test "organization_logo with large size" do
+    logo_html = organization_logo(@organization, size: :lg)
 
-    assert_includes logo_html, 'class="h-5 w-5 rounded-sm bg-muted text-muted-foreground text-xs font-medium flex items-center justify-center flex-shrink-0"'
+    # Large size maps to :lg avatar size (size-12)
+    assert_includes logo_html, "size-12"
+    assert_includes logo_html, "rounded-md"
     assert_includes logo_html, "FE"
   end
 
   test "organization_logo with small size" do
-    logo_html = organization_logo(@organization, size: :small)
+    logo_html = organization_logo(@organization, size: :sm)
 
-    assert_includes logo_html, 'class="h-4 w-4 rounded-sm bg-muted text-muted-foreground text-xs font-medium flex items-center justify-center flex-shrink-0"'
+    # Small size maps to :sm avatar size (size-6)
+    assert_includes logo_html, "size-6"
+    assert_includes logo_html, "rounded-md"
     assert_includes logo_html, "FE"
   end
 
   test "organization_logo with attached logo image (large)" do
     @organization.logo.attach(io: file_fixture("racecar.jpeg").open, filename: "racecar.jpeg", content_type: "image/jpeg")
 
-    logo_html = organization_logo(@organization, size: :large)
+    logo_html = organization_logo(@organization, size: :lg)
 
-    assert_match(/img/, logo_html)
-    assert_includes logo_html, 'class="rounded-lg size-12 object-cover"'
+    # Should contain image tag
+    assert_match(/<img/, logo_html)
     assert_includes logo_html, 'alt="FeedbackBin"'
     assert_includes logo_html, "racecar.jpeg"
+    assert_includes logo_html, "size-12"
+    assert_includes logo_html, "rounded-md"
   end
 
   test "organization_logo with attached logo image (medium)" do
     @organization.logo.attach(io: file_fixture("racecar.jpeg").open, filename: "racecar.jpeg", content_type: "image/jpeg")
 
-    logo_html = organization_logo(@organization, size: :medium)
+    logo_html = organization_logo(@organization, size: :default)
 
-    assert_match(/img/, logo_html)
-    assert_includes logo_html, 'class="h-5 w-5 rounded-sm object-cover flex-shrink-0"'
+    assert_match(/<img/, logo_html)
     assert_includes logo_html, 'alt="FeedbackBin"'
     assert_includes logo_html, "racecar.jpeg"
+    assert_includes logo_html, "size-8"
   end
 
   test "organization_logo with attached logo image (small)" do
     @organization.logo.attach(io: file_fixture("racecar.jpeg").open, filename: "racecar.jpeg", content_type: "image/jpeg")
 
-    logo_html = organization_logo(@organization, size: :small)
+    logo_html = organization_logo(@organization, size: :sm)
 
-    assert_match(/img/, logo_html)
-    assert_includes logo_html, 'class="h-4 w-4 rounded-sm object-cover flex-shrink-0"'
+    assert_match(/<img/, logo_html)
     assert_includes logo_html, 'alt="FeedbackBin"'
     assert_includes logo_html, "racecar.jpeg"
+    assert_includes logo_html, "size-6"
   end
 
   test "organization_logo with custom classes" do
-    logo_html = organization_logo(@organization, size: :large, class: "custom-class")
+    logo_html = organization_logo(@organization, size: :lg, class: "custom-class")
 
-    assert_includes logo_html, "size-12 rounded-lg bg-primary text-primary-foreground text-sm font-medium flex items-center justify-center custom-class"
-  end
-
-  test "organization_logo raises error for invalid size" do
-    assert_raises(ArgumentError, "Unknown logo size: invalid. Use :small, :medium, or :large") do
-      organization_logo(@organization, size: :invalid)
-    end
+    assert_includes logo_html, "custom-class"
+    assert_includes logo_html, "size-12"
   end
 end


### PR DESCRIPTION
- Simplified the `organization_logo` helper to utilize a new avatar rendering method, supporting default size and fallback initials.
- Updated all instances of `organization_logo` in views to reflect the new size options and improved rendering logic.
- Enhanced tests for the `organization_logo` helper to cover new size mappings and ensure correct output for attached logos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Organization avatars now use a unified avatar component with a square shape and two-letter initials.
  - Default avatar size updated to a medium “default”; standardized size tokens to sm and lg.
  - Consistent sizing across UI: switcher items use small; organization cards use large.
  - Options (like custom classes) are supported more flexibly.

- Tests
  - Updated tests to reflect new default and size tokens, verify presence of images when logos are attached, and validate sizing and classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->