### PR TITLE
Fix sub doc links with issue with trailing slashes

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -72,8 +72,8 @@ layout: default
                     </div>
                     <ul id="deployment-submenu" class="ml-4 mt-1 space-y-1 {% unless page.url contains '/docs/getting-started/deployment' %}hidden{% endunless %}">
                       <li>
-                        <a href="{{ "/docs/getting-started/deployment/" | relative_url }}"
-                           class="flex items-center px-3 py-2 text-sm rounded-lg hover:bg-muted transition-colors {% if page.url == '/docs/getting-started/deployment/' %}bg-muted text-foreground{% else %}text-muted-foreground hover:text-foreground{% endif %}">
+                        <a href="{{ "/docs/getting-started/deployment" | relative_url }}"
+                           class="flex items-center px-3 py-2 text-sm rounded-lg hover:bg-muted transition-colors {% if page.url == '/docs/getting-started/deployment' %}bg-muted text-foreground{% else %}text-muted-foreground hover:text-foreground{% endif %}">
                           Overview
                         </a>
                       </li>
@@ -105,8 +105,8 @@ layout: default
                     </div>
                     <ul id="configuration-submenu" class="ml-4 mt-1 space-y-1 {% unless page.url contains '/docs/getting-started/configuration' %}hidden{% endunless %}">
                       <li>
-                        <a href="{{ "/docs/getting-started/configuration/" | relative_url }}"
-                           class="flex items-center px-3 py-2 text-sm rounded-lg hover:bg-muted transition-colors {% if page.url == '/docs/getting-started/configuration/' %}bg-muted text-foreground{% else %}text-muted-foreground hover:text-foreground{% endif %}">
+                        <a href="{{ "/docs/getting-started/configuration" | relative_url }}"
+                           class="flex items-center px-3 py-2 text-sm rounded-lg hover:bg-muted transition-colors {% if page.url == '/docs/getting-started/configuration' %}bg-muted text-foreground{% else %}text-muted-foreground hover:text-foreground{% endif %}">
                           Overview
                         </a>
                       </li>

--- a/docs/docs/getting-started/index.md
+++ b/docs/docs/getting-started/index.md
@@ -6,7 +6,7 @@ description: "Learn how to configure and deploy FeedbackBin for your production 
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 my-8">
 
-  <a href="{{ "/docs/getting-started/deployment/" | relative_url }}" class="group flex gap-4 p-6 bg-card border border-border rounded-lg hover:shadow-lg transition-all duration-200 hover:border-primary/50">
+  <a href="{{ "/docs/getting-started/deployment" | relative_url }}" class="group flex gap-4 p-6 bg-card border border-border rounded-lg hover:shadow-lg transition-all duration-200 hover:border-primary/50">
     <div class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center group-hover:bg-primary/20 transition-colors flex-shrink-0 mt-8">
       <svg class="w-6 h-6 text-primary" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12.75 3.03v.568c0 .334.148.65.405.864l1.068.89c.442.369.535 1.01.216 1.49l-.51.766a2.25 2.25 0 01-1.161.886l-.143.048a1.107 1.107 0 00-.57 1.664c.369.555.169 1.307-.427 1.605L9 13.125l.423 1.059a.956.956 0 01-1.652.928L6.116 13.37a4.718 4.718 0 01-1.39-2.296l-.435-1.044A2.25 2.25 0 016.315 7.7l1.068-.89A2.25 2.25 0 008.25 5.25h2.25c.414 0 .75.336.75.75v1.5c0 .414.336.75.75.75s.75-.336.75-.75V4.875c0-.621.504-1.125 1.125-1.125h1.5c.621 0 1.125.504 1.125 1.125v.75c0 .414.336.75.75.75s.75-.336.75-.75v-1.5a2.25 2.25 0 00-2.25-2.25H12.75z" />
@@ -20,7 +20,7 @@ description: "Learn how to configure and deploy FeedbackBin for your production 
     </div>
   </a>
 
-  <a href="{{ "/docs/getting-started/configuration/" | relative_url }}" class="group flex gap-4 p-6 bg-card border border-border rounded-lg hover:shadow-lg transition-all duration-200 hover:border-primary/50">
+  <a href="{{ "/docs/getting-started/configuration" | relative_url }}" class="group flex gap-4 p-6 bg-card border border-border rounded-lg hover:shadow-lg transition-all duration-200 hover:border-primary/50">
     <div class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center group-hover:bg-primary/20 transition-colors flex-shrink-0 mt-8">
       <svg class="w-6 h-6 text-primary" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar highlighting for Getting Started > Deployment and Configuration by aligning links and URL matching to non-trailing-slash paths, improving navigation accuracy and reducing redirects.

* **Documentation**
  * Updated Deployment and Configuration links in Getting Started to use non-trailing-slash URLs for consistency. No visual changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->