### PR TITLE
Add admin changelog CRUD with publish/unpublish toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore vendored gems (installed locally during development).
+/vendor/bundle
+
 # Ignore all environment files.
 /.env*
 

--- a/app/controllers/admin/changelogs/publications_controller.rb
+++ b/app/controllers/admin/changelogs/publications_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Admin
+  module Changelogs
+    class PublicationsController < Admin::BaseController
+      before_action :set_changelog
+
+      def create
+        @changelog.update!(published_at: Time.current)
+        redirect_to admin_changelogs_path, notice: t(".successfully_published"), status: :see_other
+      end
+
+      def destroy
+        @changelog.update!(published_at: nil)
+        redirect_to admin_changelogs_path, notice: t(".successfully_unpublished"), status: :see_other
+      end
+
+      private
+
+        def set_changelog
+          @changelog = Changelog.find(params[:changelog_id])
+        end
+    end
+  end
+end

--- a/app/controllers/admin/changelogs/publications_controller.rb
+++ b/app/controllers/admin/changelogs/publications_controller.rb
@@ -18,7 +18,7 @@ module Admin
       private
 
         def set_changelog
-          @changelog = Changelog.find(params[:changelog_id])
+          @changelog = Current.account.changelogs.find(params[:changelog_id])
         end
     end
   end

--- a/app/controllers/admin/changelogs_controller.rb
+++ b/app/controllers/admin/changelogs_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Admin
+  class ChangelogsController < Admin::BaseController
+    before_action :set_changelog, only: [ :edit, :update, :destroy ]
+
+    def index
+      @pagy, @changelogs = pagy(Changelog.order(updated_at: :desc))
+    end
+
+    def new
+      @changelog = Changelog.new
+    end
+
+    def create
+      @changelog = Changelog.new(changelog_params)
+      @changelog.published_at = Time.current if publish_requested?
+
+      if @changelog.save
+        redirect_to admin_changelogs_path, notice: t(".successfully_created"), status: :see_other
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      @changelog.assign_attributes(changelog_params)
+
+      if publish_requested?
+        @changelog.published_at ||= Time.current
+      else
+        @changelog.published_at = nil
+      end
+
+      if @changelog.save
+        redirect_to admin_changelogs_path, notice: t(".successfully_updated"), status: :see_other
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @changelog.destroy
+      redirect_to admin_changelogs_path, notice: t(".successfully_destroyed"), status: :see_other
+    end
+
+    private
+
+      def set_changelog
+        @changelog = Changelog.find(params[:id])
+      end
+
+      def changelog_params
+        params.require(:changelog).permit(:title, :description, :kind)
+      end
+
+      def publish_requested?
+        params.dig(:changelog, :publish) == "1"
+      end
+  end
+end

--- a/app/controllers/admin/changelogs_controller.rb
+++ b/app/controllers/admin/changelogs_controller.rb
@@ -5,15 +5,15 @@ module Admin
     before_action :set_changelog, only: [ :edit, :update, :destroy ]
 
     def index
-      @pagy, @changelogs = pagy(Changelog.order(updated_at: :desc))
+      @pagy, @changelogs = pagy(Current.account.changelogs.order(updated_at: :desc))
     end
 
     def new
-      @changelog = Changelog.new
+      @changelog = Current.account.changelogs.new
     end
 
     def create
-      @changelog = Changelog.new(changelog_params)
+      @changelog = Current.account.changelogs.new(changelog_params)
       @changelog.published_at = Time.current if publish_requested?
 
       if @changelog.save
@@ -50,7 +50,7 @@ module Admin
     private
 
       def set_changelog
-        @changelog = Changelog.find(params[:id])
+        @changelog = Current.account.changelogs.find(params[:id])
       end
 
       def changelog_params

--- a/app/models/changelog.rb
+++ b/app/models/changelog.rb
@@ -13,8 +13,9 @@ class Changelog < ApplicationRecord
   scope :draft, -> { where(published_at: nil) }
   scope :published, -> { where.not(published_at: nil) }
 
-  # TODO: Investigate if we need this when we build the CRUD form for changelogs
-  attribute :published_at, default: -> { Time.current }
+  def published?
+    published_at?
+  end
 
   def self.unread?(user)
     most_recent_changelog = published.maximum(:published_at)

--- a/app/views/admin/_sidebar.html.erb
+++ b/app/views/admin/_sidebar.html.erb
@@ -64,11 +64,14 @@
           <% end %>
         </li>
         <li>
-          <div class="flex align-center border-radius txt-small font-weight-bold txt-subtle" style="gap: var(--space-3); padding: var(--space-2); cursor: not-allowed;">
+          <%= active_link_to admin_changelogs_path,
+                class: "flex align-center border-radius txt-small font-weight-bold",
+                style: "gap: var(--space-3); padding: var(--space-2);",
+                active_class: "fill-selected",
+                inactive_class: "txt-subtle" do %>
             <%= lucide_icon "megaphone", class: "size-6 flex-item-no-shrink" %>
             <%= t("layouts.admin.navigation.changelog") %>
-            <span class="txt-xx-small fill-shade txt-subtle flex-item-justify-end" style="padding-inline: var(--space-2); padding-block: var(--space-1); border-radius: 9999px;"><%= t("layouts.admin.badges.soon") %></span>
-          </div>
+          <% end %>
         </li>
         <li>
           <div class="txt-xx-small font-weight-bold txt-subtle" style="line-height: 1.5rem; margin-block-start: var(--space-8);">

--- a/app/views/admin/changelogs/_form.html.erb
+++ b/app/views/admin/changelogs/_form.html.erb
@@ -1,0 +1,43 @@
+<%# locals: (changelog:) %>
+
+<%= form_with model: changelog, url: changelog.persisted? ? admin_changelog_path(changelog) : admin_changelogs_path, method: changelog.persisted? ? :patch : :post, class: "form form--stack" do |f| %>
+  <%= render "error_messages", resource: f.object %>
+
+  <div class="form__group form__group--spacious">
+    <%= f.label :title, t(".title_label") %>
+    <%= f.text_field :title, placeholder: t(".title_placeholder"), class: "form-input", autofocus: true, required: true %>
+  </div>
+
+  <div class="form__group form__group--spacious">
+    <%= f.label :kind, t(".kind_label") %>
+    <%= f.select :kind,
+        options_for_select(
+          Changelog::TYPES.map { |k| [ t(".kind_option_#{k}"), k ] },
+          changelog.kind
+        ),
+        { prompt: t(".kind_prompt") },
+        { class: "select" } %>
+  </div>
+
+  <div class="form__group form__group--spacious">
+    <%= f.label :description, t(".body_label") %>
+    <div class="panel panel--compact panel--flush panel--flat panel--clip">
+      <%= f.rich_text_area :description, placeholder: t(".body_placeholder") %>
+    </div>
+  </div>
+
+  <div class="form__group form__group--spacious">
+    <div class="flex align-center gap-2">
+      <%= check_box_tag "changelog[publish]", "1", changelog.published?, id: "changelog_publish" %>
+      <%= label_tag "changelog_publish", t(".publish_label"), class: "txt-small font-weight-medium", style: "line-height: 1;" %>
+    </div>
+    <p class="form__helper txt-x-small"><%= changelog.published? ? t(".currently_published") : t(".currently_draft") %></p>
+  </div>
+
+  <div class="form__actions form__actions--end form__actions--spacious form__actions--offset-md">
+    <%= link_to t("cancel"), admin_changelogs_path, class: "btn btn--secondary" %>
+    <%= render Elements::ButtonComponent.new(type: :submit, variant: :default) do %>
+      <%= changelog.persisted? ? t(".save_changes") : t(".create_changelog") %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/changelogs/edit.html.erb
+++ b/app/views/admin/changelogs/edit.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, t(".title") %>
+
+<div class="container container--page">
+  <div class="page-header">
+    <div class="page-header__meta">
+      <%= link_to admin_changelogs_path, class: "txt-small txt-subtle-link flex-inline align-center" do %>
+        <%= lucide_icon "arrow-left", class: "size-4 margin-inline-end-half" %>
+        <%= t(".back_to_changelogs") %>
+      <% end %>
+    </div>
+    <h1 class="txt-xx-large font-weight-semibold"><%= t(".title") %></h1>
+    <p class="txt-small txt-subtle"><%= t(".description") %></p>
+  </div>
+
+  <%= render Elements::PanelComponent.new do |c| %>
+    <% c.with_body do %>
+      <%= render "form", changelog: @changelog %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/admin/changelogs/index.html.erb
+++ b/app/views/admin/changelogs/index.html.erb
@@ -1,0 +1,98 @@
+<% content_for :title, t(".title") %>
+
+<div class="container container--wide container--page">
+  <div class="page-header flex align-center justify-space-between">
+    <div>
+      <h1 class="txt-xx-large font-weight-semibold"><%= t(".title") %></h1>
+      <p class="txt-small txt-subtle"><%= t(".description") %></p>
+    </div>
+    <div class="txt-nowrap">
+      <%= render Elements::ButtonComponent.new(variant: :default, href: new_admin_changelog_path) do %>
+        <%= lucide_icon "plus", class: "size-4", style: "margin-inline-end: var(--space-2);" %>
+        <%= t(".new_changelog") %>
+      <% end %>
+    </div>
+  </div>
+
+  <% if @changelogs.any? %>
+    <%= render Elements::PanelComponent.new do |c| %>
+      <% c.with_body(class: "unpad") do %>
+        <ul role="list" class="divide-y">
+          <% @changelogs.each do |changelog| %>
+            <li class="flex align-center justify-space-between" style="gap: var(--space-6); padding-block: var(--space-5); padding-inline: var(--space-6);">
+              <div class="min-width" style="flex: 1 1 auto;">
+                <div class="flex align-center gap-3">
+                  <p class="txt-small font-weight-semibold overflow-ellipsis">
+                    <%= link_to changelog.title, edit_admin_changelog_path(changelog), class: "txt-link" %>
+                  </p>
+                  <%= render Elements::BadgeComponent.new(variant: changelog_badge_variant(changelog.kind)) do %>
+                    <%= changelog.kind.humanize.titleize %>
+                  <% end %>
+                  <% if changelog.published? %>
+                    <%= render Elements::BadgeComponent.new(variant: :success) do %>
+                      <%= t(".published_badge") %>
+                    <% end %>
+                  <% else %>
+                    <%= render Elements::BadgeComponent.new(variant: :secondary) do %>
+                      <%= t(".draft_badge") %>
+                    <% end %>
+                  <% end %>
+                </div>
+                <% if changelog.published? %>
+                  <p class="txt-x-small txt-subtle" style="margin-block-start: var(--space-1);">
+                    <%= t(".published_at", time: time_ago_with_tooltip(changelog.published_at)) %>
+                  </p>
+                <% end %>
+              </div>
+              <div class="flex align-center gap-3 flex-item-no-shrink">
+                <% if changelog.published? %>
+                  <%= button_to admin_changelog_publication_path(changelog),
+                        method: :delete,
+                        class: "btn btn--secondary btn--sm",
+                        data: { turbo_confirm: t("are_you_sure") } do %>
+                    <%= t(".unpublish_action") %>
+                  <% end %>
+                <% else %>
+                  <%= button_to admin_changelog_publication_path(changelog),
+                        method: :post,
+                        class: "btn btn--sm" do %>
+                    <%= t(".publish_action") %>
+                  <% end %>
+                <% end %>
+                <%= link_to edit_admin_changelog_path(changelog), class: "txt-subtle" do %>
+                  <%= lucide_icon "pencil", class: "size-5" %>
+                  <span class="visually-hidden"><%= t("edit") %></span>
+                <% end %>
+                <%= link_to admin_changelog_path(changelog),
+                      class: "txt-small",
+                      style: "color: var(--color-destructive);",
+                      data: { "turbo-method": :delete, turbo_confirm: t("are_you_sure") } do %>
+                  <%= lucide_icon "trash-2", class: "size-5" %>
+                  <span class="visually-hidden"><%= t("delete") %></span>
+                <% end %>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+
+    <% if @pagy.last > 1 %>
+      <div class="flex align-center justify-space-between" style="padding: var(--space-4) var(--space-6);">
+        <%== @pagy.info_tag %>
+        <%== @pagy.series_nav %>
+      </div>
+    <% end %>
+  <% else %>
+    <%= render Elements::PanelComponent.new do |c| %>
+      <% c.with_body(class: "txt-align-center", style: "padding: var(--space-8);") do %>
+        <%= lucide_icon "megaphone", class: "size-12 txt-subtle center" %>
+        <h3 class="txt-medium font-weight-bold margin-block-start"><%= t(".no_changelogs_title") %></h3>
+        <p class="txt-small txt-subtle margin-block-start-half"><%= t(".no_changelogs_description") %></p>
+        <div style="margin-block-start: var(--space-6);">
+          <%= link_to t(".create_first_changelog"), new_admin_changelog_path, class: "btn btn--primary" %>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/admin/changelogs/index.html.erb
+++ b/app/views/admin/changelogs/index.html.erb
@@ -40,7 +40,7 @@
                 </div>
                 <% if changelog.published? %>
                   <p class="txt-x-small txt-subtle" style="margin-block-start: var(--space-1);">
-                    <%= t(".published_at", time: time_ago_with_tooltip(changelog.published_at)) %>
+                    <%= t(".published_at_html", time: time_ago_with_tooltip(changelog.published_at)) %>
                   </p>
                 <% end %>
               </div>

--- a/app/views/admin/changelogs/new.html.erb
+++ b/app/views/admin/changelogs/new.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, t(".title") %>
+
+<div class="container container--page">
+  <div class="page-header">
+    <div class="page-header__meta">
+      <%= link_to admin_changelogs_path, class: "txt-small txt-subtle-link flex-inline align-center" do %>
+        <%= lucide_icon "arrow-left", class: "size-4 margin-inline-end-half" %>
+        <%= t(".back_to_changelogs") %>
+      <% end %>
+    </div>
+    <h1 class="txt-xx-large font-weight-semibold"><%= t(".title") %></h1>
+    <p class="txt-small txt-subtle"><%= t(".description") %></p>
+  </div>
+
+  <%= render Elements::PanelComponent.new do |c| %>
+    <% c.with_body do %>
+      <%= render "form", changelog: @changelog %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/changelogs/show.html.erb
+++ b/app/views/changelogs/show.html.erb
@@ -7,7 +7,7 @@
         <%= lucide_icon "chevron-left", style: "inline-size: 1rem; block-size: 1rem;" %>
         <span><%= t(".back") %></span>
       <% end %>
-      <% if authenticated? && Current.user&.admin? %>
+      <% if authenticated? && Current.admin? %>
         <%= link_to t(".edit"), edit_admin_changelog_path(@changelog), class: "btn btn--secondary btn--sm" %>
       <% end %>
     </div>

--- a/app/views/changelogs/show.html.erb
+++ b/app/views/changelogs/show.html.erb
@@ -2,10 +2,13 @@
 
 <section class="center pad-inline" style="margin-block-start: var(--space-6);">
   <div class="container">
-    <div class="page-header">
+    <div class="page-header flex align-center justify-space-between">
       <%= link_to changelogs_path, class: "flex-inline align-center gap-half txt-small txt-subtle" do %>
         <%= lucide_icon "chevron-left", style: "inline-size: 1rem; block-size: 1rem;" %>
         <span><%= t(".back") %></span>
+      <% end %>
+      <% if authenticated? && Current.user&.admin? %>
+        <%= link_to t(".edit"), edit_admin_changelog_path(@changelog), class: "btn btn--secondary btn--sm" %>
       <% end %>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,54 @@ en:
             role:
               account_owner_cannot_change: cannot be changed for account owner
   admin:
+    changelogs:
+      create:
+        successfully_created: Changelog entry was successfully created.
+      destroy:
+        successfully_destroyed: Changelog entry was successfully deleted.
+      edit:
+        back_to_changelogs: Back to Changelogs
+        description: Update the details of this changelog entry.
+        title: Edit Changelog Entry
+      form:
+        body_label: Body
+        body_placeholder: Describe the change...
+        create_changelog: Create Changelog Entry
+        currently_draft: This entry is saved as a draft and not visible to users.
+        currently_published: This entry is published and visible to users.
+        kind_label: Type
+        kind_option_fix: Bug Fix
+        kind_option_improvement: Improvement
+        kind_option_new: New Feature
+        kind_option_update: Update
+        kind_prompt: Select a type
+        publish_label: Publish now
+        save_changes: Save Changes
+        title_label: Title
+        title_placeholder: What's new?
+      index:
+        create_first_changelog: Create Changelog Entry
+        description: Manage changelog entries visible to your users.
+        draft_badge: Draft
+        new_changelog: New Changelog Entry
+        no_changelogs_description: Create your first entry to announce features, improvements, and bug fixes.
+        no_changelogs_title: No changelog entries yet
+        publish_action: Publish
+        published_at: Published %{time}
+        published_badge: Published
+        title: Changelog
+        unpublish_action: Unpublish
+      new:
+        back_to_changelogs: Back to Changelogs
+        description: Create a new entry to announce a feature or update.
+        title: New Changelog Entry
+      publications:
+        create:
+          successfully_published: Changelog entry was published.
+        destroy:
+          successfully_unpublished: Changelog entry was unpublished.
+      update:
+        successfully_updated: Changelog entry was successfully updated.
     dashboard:
       show:
         description: Overview of your application's activity and key metrics
@@ -468,6 +516,7 @@ en:
       title: What's New
     show:
       back: Back
+      edit: Edit in Admin
   comments:
     comment:
       comment_settings: Comment settings

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,7 +74,7 @@ en:
         no_changelogs_description: Create your first entry to announce features, improvements, and bug fixes.
         no_changelogs_title: No changelog entries yet
         publish_action: Publish
-        published_at: Published %{time}
+        published_at_html: Published %{time}
         published_badge: Published
         title: Changelog
         unpublish_action: Unpublish

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,7 +128,7 @@ Rails.application.routes.draw do
       end
     end
     resources :ideas, only: [ :index, :show ]
-    resources :changelogs do
+    resources :changelogs, only: %i[index new create edit update destroy] do
       scope module: :changelogs do
         resource :publication, only: [ :create, :destroy ]
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,11 @@ Rails.application.routes.draw do
       end
     end
     resources :ideas, only: [ :index, :show ]
+    resources :changelogs do
+      scope module: :changelogs do
+        resource :publication, only: [ :create, :destroy ]
+      end
+    end
     resources :invitations, only: [ :index, :new, :create, :destroy ] do
       member do
         post :resend

--- a/test/controllers/admin/changelogs/publications_controller_test.rb
+++ b/test/controllers/admin/changelogs/publications_controller_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Admin
+  module Changelogs
+    class PublicationsControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @admin = users(:shane)
+        @published = changelogs(:one)
+        @draft = changelogs(:draft)
+        sign_in_as @admin
+      end
+
+      test "should publish a draft entry" do
+        assert_nil @draft.published_at
+
+        post admin_changelog_publication_url(@draft)
+
+        assert_redirected_to admin_changelogs_path
+        assert_equal I18n.t("admin.changelogs.publications.create.successfully_published"), flash[:notice]
+        assert_not_nil @draft.reload.published_at
+      end
+
+      test "should unpublish a published entry" do
+        assert_not_nil @published.published_at
+
+        delete admin_changelog_publication_url(@published)
+
+        assert_redirected_to admin_changelogs_path
+        assert_equal I18n.t("admin.changelogs.publications.destroy.successfully_unpublished"), flash[:notice]
+        assert_nil @published.reload.published_at
+      end
+
+      test "non-admin cannot publish" do
+        sign_in_as users(:john)
+
+        post admin_changelog_publication_url(@draft)
+
+        assert_response :forbidden
+      end
+
+      test "non-admin cannot unpublish" do
+        sign_in_as users(:john)
+
+        delete admin_changelog_publication_url(@published)
+
+        assert_response :forbidden
+      end
+    end
+  end
+end

--- a/test/controllers/admin/changelogs_controller_test.rb
+++ b/test/controllers/admin/changelogs_controller_test.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Admin
+  class ChangelogsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @admin = users(:shane)
+      @changelog = changelogs(:one)
+      @draft = changelogs(:draft)
+      sign_in_as @admin
+    end
+
+    test "should get index" do
+      get admin_changelogs_url
+
+      assert_response :success
+    end
+
+    test "index shows both draft and published entries" do
+      get admin_changelogs_url
+
+      assert_response :success
+      assert_select "a", text: @changelog.title
+      assert_select "a", text: @draft.title
+    end
+
+    test "should not get index if not an admin" do
+      sign_in_as users(:john)
+
+      get admin_changelogs_url
+
+      assert_response :forbidden
+    end
+
+    test "should get new" do
+      get new_admin_changelog_url
+
+      assert_response :success
+    end
+
+    test "should not get new if not an admin" do
+      sign_in_as users(:john)
+
+      get new_admin_changelog_url
+
+      assert_response :forbidden
+    end
+
+    test "should create changelog as draft when publish not checked" do
+      assert_difference "Changelog.count", 1 do
+        post admin_changelogs_url, params: { changelog: { title: "New Entry", kind: "new", description: "Some content" } }
+      end
+
+      assert_redirected_to admin_changelogs_path
+      assert_equal I18n.t("admin.changelogs.create.successfully_created"), flash[:notice]
+      assert_nil Changelog.last.published_at
+    end
+
+    test "should create changelog as published when publish checked" do
+      assert_difference "Changelog.count", 1 do
+        post admin_changelogs_url, params: { changelog: { title: "New Entry", kind: "new", description: "Some content", publish: "1" } }
+      end
+
+      assert_redirected_to admin_changelogs_path
+      assert_not_nil Changelog.last.published_at
+    end
+
+    test "renders 422 on invalid create" do
+      assert_no_difference "Changelog.count" do
+        post admin_changelogs_url, params: { changelog: { title: "", kind: "new", description: "content" } }
+      end
+
+      assert_response :unprocessable_entity
+    end
+
+    test "non-admin cannot create" do
+      sign_in_as users(:john)
+
+      post admin_changelogs_url, params: { changelog: { title: "x", kind: "new", description: "x" } }
+
+      assert_response :forbidden
+    end
+
+    test "should get edit" do
+      get edit_admin_changelog_url(@changelog)
+
+      assert_response :success
+    end
+
+    test "should not get edit if not an admin" do
+      sign_in_as users(:john)
+
+      get edit_admin_changelog_url(@changelog)
+
+      assert_response :forbidden
+    end
+
+    test "should update changelog" do
+      patch admin_changelog_url(@changelog), params: { changelog: { title: "Updated Title", kind: "fix", description: "Updated content", publish: "1" } }
+
+      assert_redirected_to admin_changelogs_path
+      assert_equal I18n.t("admin.changelogs.update.successfully_updated"), flash[:notice]
+      assert_equal "Updated Title", @changelog.reload.title
+    end
+
+    test "updating preserves existing published_at when publish checked" do
+      original_published_at = @changelog.published_at
+
+      patch admin_changelog_url(@changelog), params: { changelog: { title: "Updated", kind: "new", description: "content", publish: "1" } }
+
+      assert_in_delta original_published_at, @changelog.reload.published_at, 1.second
+    end
+
+    test "updating unpublishes when publish unchecked" do
+      patch admin_changelog_url(@changelog), params: { changelog: { title: "Updated", kind: "new", description: "content" } }
+
+      assert_nil @changelog.reload.published_at
+    end
+
+    test "renders 422 on invalid update" do
+      patch admin_changelog_url(@changelog), params: { changelog: { title: "", kind: "new", description: "content" } }
+
+      assert_response :unprocessable_entity
+    end
+
+    test "non-admin cannot update" do
+      sign_in_as users(:john)
+
+      patch admin_changelog_url(@changelog), params: { changelog: { title: "x", kind: "fix", description: "x" } }
+
+      assert_response :forbidden
+    end
+
+    test "should destroy changelog" do
+      assert_difference "Changelog.count", -1 do
+        delete admin_changelog_url(@changelog)
+      end
+
+      assert_redirected_to admin_changelogs_path
+      assert_equal I18n.t("admin.changelogs.destroy.successfully_destroyed"), flash[:notice]
+    end
+
+    test "non-admin cannot destroy" do
+      sign_in_as users(:john)
+
+      delete admin_changelog_url(@changelog)
+
+      assert_response :forbidden
+    end
+  end
+end

--- a/test/controllers/admin/changelogs_controller_test.rb
+++ b/test/controllers/admin/changelogs_controller_test.rb
@@ -148,5 +148,43 @@ module Admin
 
       assert_response :forbidden
     end
+
+    test "admin of another account cannot access changelogs outside their tenant" do
+      tenanted(accounts(:acme)) do
+        sign_in_as users(:acme_admin)
+
+        get edit_admin_changelog_url(@changelog)
+
+        assert_response :not_found
+
+        patch admin_changelog_url(@changelog), params: { changelog: { title: "pwned", kind: "fix", description: "x" } }
+
+        assert_response :not_found
+
+        assert_no_difference "Changelog.count" do
+          delete admin_changelog_url(@changelog)
+        end
+        assert_response :not_found
+
+        post admin_changelog_publication_url(@draft)
+
+        assert_response :not_found
+        assert_nil @draft.reload.published_at
+
+        delete admin_changelog_publication_url(@changelog)
+
+        assert_response :not_found
+        assert_not_nil @changelog.reload.published_at
+      end
+    end
+
+    test "index does not leak changelogs from other accounts" do
+      other_changelog = accounts(:acme).changelogs.create!(title: "Acme secret", kind: "new", description: "should not leak")
+
+      get admin_changelogs_url
+
+      assert_response :success
+      assert_select "a", text: other_changelog.title, count: 0
+    end
   end
 end

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -43,3 +43,9 @@ changelog_body_two:
   record: two (Changelog)
   name: description
   body: <p>Added upvotes to the website!</p>
+
+changelog_body_draft:
+  account: feedbackbin
+  record: draft (Changelog)
+  name: description
+  body: <p>This improvement is not yet published.</p>

--- a/test/fixtures/changelogs.yml
+++ b/test/fixtures/changelogs.yml
@@ -9,3 +9,8 @@ two:
   kind: fix
   title: Fixed a bug that was causing issues
   published_at: <%= 3.hours.ago %>
+
+draft:
+  account: feedbackbin
+  kind: improvement
+  title: An improvement that is not yet published


### PR DESCRIPTION
- Admin::ChangelogsController with full CRUD (index, new, create, edit, update, destroy)
- Admin::Changelogs::PublicationsController for quick publish/unpublish toggle from list view
- Routes under namespace :admin with nested publication resource
- Admin list view shows all entries (draft + published) sorted by updated_at, with status badges
- Form supports title, kind selector, rich text body, and publish checkbox
- Remove published_at default from Changelog model (was causing all new entries to default to published)
- Add published? helper method to Changelog model
- Edit shortcut link on public /changelog/:id show page, visible only to admins
- Replace "Soon" sidebar placeholder with active navigation link
- Full i18n coverage for all new views and controller flash messages
- Tests for both controllers covering CRUD, publish/unpublish toggle, and admin-only authorization

https://claude.ai/code/session_01NoKjHxc7LE18PaVEdwnSeB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin changelog management UI: list, create, edit, delete, and publish/unpublish entries with publish state and timestamps.
  * Sidebar link to changelogs and conditional edit link on public changelog pages.
  * Changelog form with title, kind, description, and publish toggle.

* **Tests**
  * Comprehensive tests for admin changelog CRUD, publish/unpublish flows, authorization, and tenant isolation.

* **Chores**
  * Updated .gitignore to ignore local vendored gems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->