### PR TITLE
Add roadmap visibility toggle (public/admin only)

### DIFF
--- a/app/controllers/admin/settings/brandings_controller.rb
+++ b/app/controllers/admin/settings/brandings_controller.rb
@@ -28,7 +28,8 @@ module Admin
             :show_company_name,
             :logo_link,
             :favicon,
-            :og_image
+            :og_image,
+            :roadmap_public
           )
         end
     end

--- a/app/controllers/roadmap_controller.rb
+++ b/app/controllers/roadmap_controller.rb
@@ -24,7 +24,7 @@ class RoadmapController < ApplicationController
 
     def require_roadmap_access
       return if Current.account.roadmap_public?
-      return if Current.user&.admin?
+      return if Current.admin?
 
       if authenticated?
         head :forbidden

--- a/app/controllers/roadmap_controller.rb
+++ b/app/controllers/roadmap_controller.rb
@@ -2,6 +2,8 @@
 
 class RoadmapController < ApplicationController
   allow_unauthenticated_access only: %i[index]
+  before_action :require_roadmap_access, only: %i[index]
+
   # GET /roadmap
   def index
     @boards = Board.ordered
@@ -19,6 +21,17 @@ class RoadmapController < ApplicationController
   end
 
   private
+
+    def require_roadmap_access
+      return if Current.account.roadmap_public?
+      return if Current.user&.admin?
+
+      if authenticated?
+        head :forbidden
+      else
+        request_authentication
+      end
+    end
 
     def roadmap_data(selected_board, search_query)
       # Get only statuses visible on roadmap, ordered by position

--- a/app/views/admin/settings/brandings/show.html.erb
+++ b/app/views/admin/settings/brandings/show.html.erb
@@ -85,6 +85,20 @@
                                     "block-size: 8rem; inline-size: auto;" :
                                     "block-size: 8rem; inline-size: auto; background-color: var(--color-muted); object-fit: contain; padding: var(--space-4);")) %>
               </div>
+              <div class="grid" style="gap: var(--space-3);">
+                <%= f.label :roadmap_public, t(".roadmap_visibility"), class: "txt-small font-weight-medium" %>
+                <div class="flex flex-column" style="gap: var(--space-2);">
+                  <div class="flex align-center" style="gap: var(--space-2);">
+                    <%= f.radio_button :roadmap_public, true, style: "inline-size: 1rem; block-size: 1rem;" %>
+                    <%= f.label :roadmap_public_true, t(".roadmap_public"), class: "font-weight-normal" %>
+                  </div>
+                  <div class="flex align-center" style="gap: var(--space-2);">
+                    <%= f.radio_button :roadmap_public, false, style: "inline-size: 1rem; block-size: 1rem;" %>
+                    <%= f.label :roadmap_public_false, t(".roadmap_admin_only"), class: "font-weight-normal" %>
+                  </div>
+                </div>
+                <p class="txt-x-small txt-subtle"><%= t(".roadmap_visibility_hint") %></p>
+              </div>
             </div>
 
             <div class="flex align-center justify-end" style="margin-block-start: var(--space-8); gap: var(--space-3);">

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -18,11 +18,13 @@
                 class: "header__link",
                 active_class: "header__link--active",
                 inactive_class: "" %>
-          <%= active_link_to t(".links.roadmap"),
-                roadmap_path,
-                class: "header__link",
-                active_class: "header__link--active",
-                inactive_class: "" %>
+          <% if Current.account.roadmap_public? || Current.user&.admin? %>
+            <%= active_link_to t(".links.roadmap"),
+                  roadmap_path,
+                  class: "header__link",
+                  active_class: "header__link--active",
+                  inactive_class: "" %>
+          <% end %>
         </div>
       </div>
 
@@ -161,11 +163,13 @@
             class: "header__mobile-link",
             active_class: "header__mobile-link--active",
             inactive_class: "" %>
-      <%= active_link_to t(".links.roadmap"),
-            roadmap_path,
-            class: "header__mobile-link",
-            active_class: "header__mobile-link--active",
-            inactive_class: "" %>
+      <% if Current.account.roadmap_public? || Current.user&.admin? %>
+        <%= active_link_to t(".links.roadmap"),
+              roadmap_path,
+              class: "header__mobile-link",
+              active_class: "header__mobile-link--active",
+              inactive_class: "" %>
+      <% end %>
     </div>
     <div class="border-top pad-block-start pad-block-end-half">
       <% if authenticated? && Current.user %>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -18,7 +18,7 @@
                 class: "header__link",
                 active_class: "header__link--active",
                 inactive_class: "" %>
-          <% if Current.account.roadmap_public? || Current.user&.admin? %>
+          <% if Current.account.roadmap_public? || Current.admin? %>
             <%= active_link_to t(".links.roadmap"),
                   roadmap_path,
                   class: "header__link",
@@ -163,7 +163,7 @@
             class: "header__mobile-link",
             active_class: "header__mobile-link--active",
             inactive_class: "" %>
-      <% if Current.account.roadmap_public? || Current.user&.admin? %>
+      <% if Current.account.roadmap_public? || Current.admin? %>
         <%= active_link_to t(".links.roadmap"),
               roadmap_path,
               class: "header__mobile-link",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,6 +184,10 @@ en:
           name: Account name
           og_image: Open Graph Image
           og_image_hint: Used when sharing links on social media. Recommended size 1200×630px. Maximum 2MB.
+          roadmap_admin_only: Admin only — visible to admin users only
+          roadmap_public: Public — visible to everyone
+          roadmap_visibility: Roadmap visibility
+          roadmap_visibility_hint: Controls whether the roadmap page is accessible to the public or restricted to admin users.
           save_changes: Save changes
           title: Branding
           upload_favicon: Upload Favicon

--- a/db/migrate/20260310000001_add_roadmap_public_to_accounts.rb
+++ b/db/migrate/20260310000001_add_roadmap_public_to_accounts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRoadmapPublicToAccounts < ActiveRecord::Migration[8.2]
+  def change
+    add_column :accounts, :roadmap_public, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_02_06_120002) do
+ActiveRecord::Schema[8.2].define(version: 2026_03_10_000001) do
   create_table "account_external_id_sequences", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -23,6 +23,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_02_06_120002) do
     t.bigint "external_account_id", null: false
     t.string "logo_link"
     t.string "name", null: false
+    t.boolean "roadmap_public", default: true, null: false
     t.boolean "show_company_name", default: true, null: false
     t.datetime "updated_at", null: false
     t.index ["external_account_id"], name: "index_accounts_on_external_account_id", unique: true

--- a/test/controllers/admin/settings/brandings_controller_test.rb
+++ b/test/controllers/admin/settings/brandings_controller_test.rb
@@ -83,6 +83,15 @@ module Admin
         assert_predicate accounts(:feedbackbin).reload.og_image, :attached?
       end
 
+      test "should update roadmap_public" do
+        patch admin_settings_branding_url, params: {
+          account: { roadmap_public: false }
+        }
+
+        assert_redirected_to admin_settings_branding_url
+        assert_not accounts(:feedbackbin).reload.roadmap_public
+      end
+
       test "should reject invalid logo_link" do
         patch admin_settings_branding_url, params: {
           account: { logo_link: "javascript:alert('xss')" }

--- a/test/controllers/roadmap_controller_test.rb
+++ b/test/controllers/roadmap_controller_test.rb
@@ -25,6 +25,32 @@ class RoadmapControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "private roadmap redirects unauthenticated users to sign in" do
+    accounts(:feedbackbin).update!(roadmap_public: false)
+
+    get roadmap_url
+
+    assert_redirected_to sign_in_url
+  end
+
+  test "private roadmap allows admin access" do
+    accounts(:feedbackbin).update!(roadmap_public: false)
+    sign_in_as users(:shane)
+
+    get roadmap_url
+
+    assert_response :success
+  end
+
+  test "private roadmap returns forbidden for regular members" do
+    accounts(:feedbackbin).update!(roadmap_public: false)
+    sign_in_as users(:john)
+
+    get roadmap_url
+
+    assert_response :forbidden
+  end
+
   test "displays ideas in their status columns" do
     sign_in_as users(:shane)
 


### PR DESCRIPTION
Give organization admins control over whether their product roadmap is
publicly accessible or restricted to admin users only.

- Add `roadmap_public` boolean to accounts (default: true)
- Gate RoadmapController access: admins pass, members get 403, visitors
  get redirected to sign-in
- Hide roadmap nav link when private (unless user is admin)
- Add radio toggle in Admin > Settings > Branding
- Add controller and integration tests

https://claude.ai/code/session_01NtWBQvFtnQRUaXnUdTBUL2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new branding setting to toggle roadmap visibility between public and admin-only access.
  * Roadmap navigation link now displays conditionally based on configured visibility settings.
  * Roadmap page enforces access control matching the visibility configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->