### PR TITLE
Add idea comment lock (is_comments_locked)

### DIFF
--- a/app/controllers/ideas/comment_locks_controller.rb
+++ b/app/controllers/ideas/comment_locks_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Ideas
+  class CommentLocksController < ApplicationController
+    include IdeaScoped
+    before_action :ensure_admin
+
+    # POST /ideas/:idea_id/comment_lock
+    def create
+      @idea.update!(is_comments_locked: true)
+
+      respond_to do |format|
+        format.html { redirect_to @idea, notice: t(".locked") }
+        format.turbo_stream
+      end
+    end
+
+    # DELETE /ideas/:idea_id/comment_lock
+    def destroy
+      @idea.update!(is_comments_locked: false)
+
+      respond_to do |format|
+        format.html { redirect_to @idea, notice: t(".unlocked") }
+        format.turbo_stream
+      end
+    end
+  end
+end

--- a/app/controllers/ideas/comment_locks_controller.rb
+++ b/app/controllers/ideas/comment_locks_controller.rb
@@ -7,7 +7,7 @@ module Ideas
 
     # POST /ideas/:idea_id/comment_lock
     def create
-      @idea.update!(is_comments_locked: true)
+      @idea.update!(comments_locked: true)
 
       respond_to do |format|
         format.html { redirect_to @idea, notice: t(".locked") }
@@ -17,7 +17,7 @@ module Ideas
 
     # DELETE /ideas/:idea_id/comment_lock
     def destroy
-      @idea.update!(is_comments_locked: false)
+      @idea.update!(comments_locked: false)
 
       respond_to do |format|
         format.html { redirect_to @idea, notice: t(".unlocked") }

--- a/app/controllers/ideas/comments_controller.rb
+++ b/app/controllers/ideas/comments_controller.rb
@@ -92,7 +92,7 @@ class Ideas::CommentsController < ApplicationController
       return unless @idea.comments_locked? && !Current.user&.admin?
 
       respond_to do |format|
-        format.html { redirect_to @idea, alert: t(".comments_locked") }
+        format.html { redirect_to @idea, alert: t("ideas.comments.create.comments_locked") }
         format.turbo_stream { head :forbidden }
         format.json { head :forbidden }
       end

--- a/app/controllers/ideas/comments_controller.rb
+++ b/app/controllers/ideas/comments_controller.rb
@@ -89,7 +89,7 @@ class Ideas::CommentsController < ApplicationController
     end
 
     def ensure_comments_not_locked
-      return unless @idea.is_comments_locked? && !Current.user&.admin?
+      return unless @idea.comments_locked? && !Current.user&.admin?
 
       respond_to do |format|
         format.html { redirect_to @idea, alert: t(".comments_locked") }

--- a/app/controllers/ideas/comments_controller.rb
+++ b/app/controllers/ideas/comments_controller.rb
@@ -7,6 +7,7 @@ class Ideas::CommentsController < ApplicationController
 
   before_action :set_comment, only: %i[show edit update destroy]
   before_action :ensure_permission_to_administer_comment, only: %i[edit update destroy]
+  before_action :ensure_comments_not_locked, only: %i[create]
 
   def show
     render "comments/show"
@@ -85,6 +86,16 @@ class Ideas::CommentsController < ApplicationController
 
     def ensure_permission_to_administer_comment
       head :forbidden unless Current.user&.can_administer_comment?(@comment)
+    end
+
+    def ensure_comments_not_locked
+      return unless @idea.is_comments_locked? && !Current.user&.admin?
+
+      respond_to do |format|
+        format.html { redirect_to @idea, alert: t(".comments_locked") }
+        format.turbo_stream { head :forbidden }
+        format.json { head :forbidden }
+      end
     end
 
     def comment_params

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (comment:, idea:) %>
+<%# locals: (comment:) %>
 
 <%= turbo_frame_tag dom_id(comment), class: "display-block pad-block", style: "scroll-margin-block-start: var(--space-4);" do %>
   <% if comment.creator.system? %>
@@ -84,7 +84,7 @@
         </div>
       </div>
 
-      <% can_reply = authenticated? && (!idea.is_comments_locked? || Current.user.admin?) %>
+      <% can_reply = authenticated? && (!comment.idea.comments_locked? || Current.user.admin?) %>
       <% if comment.replies.any? || can_reply %>
         <div class="replies-section">
           <div id="<%= dom_id(comment) %>_replies">

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (comment:) %>
+<%# locals: (comment:, idea:) %>
 
 <%= turbo_frame_tag dom_id(comment), class: "display-block pad-block", style: "scroll-margin-block-start: var(--space-4);" do %>
   <% if comment.creator.system? %>
@@ -84,13 +84,14 @@
         </div>
       </div>
 
-      <% if comment.replies.any? || authenticated? %>
+      <% can_reply = authenticated? && (!idea.is_comments_locked? || Current.user.admin?) %>
+      <% if comment.replies.any? || can_reply %>
         <div class="replies-section">
           <div id="<%= dom_id(comment) %>_replies">
             <%= render partial: "comments/reply", collection: comment.replies.ordered, as: :reply %>
           </div>
 
-          <% if authenticated? %>
+          <% if can_reply %>
             <div id="<%= dom_id(comment) %>_reply_form" class="pad">
               <%= render partial: "comments/thread_reply_form", locals: { parent: comment } %>
             </div>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -22,7 +22,7 @@
         </div>
 
         <%= tag.div id: "idea_#{idea.id}_comments", class: "divide-y" do %>
-          <%= render partial: "comments/comment", collection: top_level_comments, locals: { idea: idea } %>
+          <%= render partial: "comments/comment", collection: top_level_comments %>
         <% end %>
       <% end %>
 

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -22,7 +22,7 @@
         </div>
 
         <%= tag.div id: "idea_#{idea.id}_comments", class: "divide-y" do %>
-          <%= render partial: "comments/comment", collection: top_level_comments %>
+          <%= render partial: "comments/comment", collection: top_level_comments, locals: { idea: idea } %>
         <% end %>
       <% end %>
 

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,6 +1,11 @@
 <%# locals: (comment:, idea:) %>
 
-<% if authenticated? %>
+<% if idea.is_comments_locked? && !Current.user&.admin? %>
+  <p class="margin-block txt-normal txt-subtle">
+    <%= lucide_icon "lock", class: "size-4" %>
+    <%= t(".discussion_locked") %>
+  </p>
+<% elsif authenticated? %>
   <%= turbo_frame_tag "idea_comment_form" do %>
     <div class="flex align-start">
       <%= form_with model: comment, url: idea_comments_path(idea), class: "margin-block full-width" do |form| %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (comment:, idea:) %>
 
-<% if idea.is_comments_locked? && !Current.user&.admin? %>
+<% if idea.comments_locked? && !Current.user&.admin? %>
   <p class="margin-block txt-normal txt-subtle">
     <%= lucide_icon "lock", class: "size-4" %>
     <%= t(".discussion_locked") %>

--- a/app/views/ideas/comment_locks/create.turbo_stream.erb
+++ b/app/views/ideas/comment_locks/create.turbo_stream.erb
@@ -1,0 +1,20 @@
+<%= turbo_stream.update "idea-comment-lock-button" do %>
+  <%= render Elements::DropdownMenuComponent::ItemComponent.new(
+    id: "idea-comment-lock-button",
+    href: idea_comment_lock_path(@idea),
+    method: :delete
+  ) do %>
+    <%= t("ideas.show.unlock_discussion") %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.update "idea-comments-locked-badge" do %>
+  <%= render Elements::BadgeComponent.new(variant: :secondary) do %>
+    <%= lucide_icon "lock" %>
+    <%= t("ideas.show.comments_locked") %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.update "idea_comment_form" do %>
+  <%= render partial: "comments/form", locals: { comment: Comment.new, idea: @idea } %>
+<% end %>

--- a/app/views/ideas/comment_locks/destroy.turbo_stream.erb
+++ b/app/views/ideas/comment_locks/destroy.turbo_stream.erb
@@ -8,9 +8,7 @@
   <% end %>
 <% end %>
 
-<%= turbo_stream.update "idea-comments-locked-badge" do %>
-  <%# Empty - removes the badge when unlocked %>
-<% end %>
+<%= turbo_stream.update "idea-comments-locked-badge", "" %>
 
 <%= turbo_stream.update "idea_comment_form" do %>
   <%= render partial: "comments/form", locals: { comment: Comment.new, idea: @idea } %>

--- a/app/views/ideas/comment_locks/destroy.turbo_stream.erb
+++ b/app/views/ideas/comment_locks/destroy.turbo_stream.erb
@@ -1,0 +1,17 @@
+<%= turbo_stream.update "idea-comment-lock-button" do %>
+  <%= render Elements::DropdownMenuComponent::ItemComponent.new(
+    id: "idea-comment-lock-button",
+    href: idea_comment_lock_path(@idea),
+    method: :post
+  ) do %>
+    <%= t("ideas.show.lock_discussion") %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.update "idea-comments-locked-badge" do %>
+  <%# Empty - removes the badge when unlocked %>
+<% end %>
+
+<%= turbo_stream.update "idea_comment_form" do %>
+  <%= render partial: "comments/form", locals: { comment: Comment.new, idea: @idea } %>
+<% end %>

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -39,7 +39,7 @@
               </span>
 
               <span id="idea-comments-locked-badge">
-                <% if @idea.is_comments_locked? %>
+                <% if @idea.comments_locked? %>
                   <%= render Elements::BadgeComponent.new(variant: :secondary) do %>
                     <%= lucide_icon "lock" %>
                     <%= t(".comments_locked") %>
@@ -80,7 +80,7 @@
                       <% end %>
                     <% end %>
 
-                    <% if @idea.is_comments_locked? %>
+                    <% if @idea.comments_locked? %>
                       <% dropdown.with_item_content(
                         id: "idea-comment-lock-button",
                         href: idea_comment_lock_path(@idea),

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -37,6 +37,15 @@
                   <% end %>
                 <% end %>
               </span>
+
+              <span id="idea-comments-locked-badge">
+                <% if @idea.is_comments_locked? %>
+                  <%= render Elements::BadgeComponent.new(variant: :secondary) do %>
+                    <%= lucide_icon "lock" %>
+                    <%= t(".comments_locked") %>
+                  <% end %>
+                <% end %>
+              </span>
             </div>
 
             <div class="flex align-center gap-half">
@@ -68,6 +77,24 @@
                         method: :post
                       ) do %>
                         <%= t(".pin") %>
+                      <% end %>
+                    <% end %>
+
+                    <% if @idea.is_comments_locked? %>
+                      <% dropdown.with_item_content(
+                        id: "idea-comment-lock-button",
+                        href: idea_comment_lock_path(@idea),
+                        method: :delete
+                      ) do %>
+                        <%= t(".unlock_discussion") %>
+                      <% end %>
+                    <% else %>
+                      <% dropdown.with_item_content(
+                        id: "idea-comment-lock-button",
+                        href: idea_comment_lock_path(@idea),
+                        method: :post
+                      ) do %>
+                        <%= t(".lock_discussion") %>
                       <% end %>
                     <% end %>
                   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -583,10 +583,11 @@ en:
         unlocked: Discussion has been unlocked.
     comments:
       create:
-        comments_locked: Discussion is locked.
         successfully_created: Comment was successfully created.
       destroy:
         successfully_destroyed: Comment was successfully deleted.
+      ensure_comments_not_locked:
+        comments_locked: Discussion is locked.
       update:
         successfully_updated: Comment was successfully updated.
       votes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -540,6 +540,7 @@ en:
         top: Top
     form:
       comment_placeholder: Write a comment...
+      discussion_locked: Discussion is locked.
     reply:
       copy_link: Copy link
       quote_reply: Quote reply
@@ -575,8 +576,14 @@ en:
     was: was
     you: You
   ideas:
+    comment_locks:
+      create:
+        locked: Discussion has been locked.
+      destroy:
+        unlocked: Discussion has been unlocked.
     comments:
       create:
+        comments_locked: Discussion is locked.
         successfully_created: Comment was successfully created.
       destroy:
         successfully_destroyed: Comment was successfully deleted.
@@ -624,9 +631,12 @@ en:
         unpinned: Idea has been unpinned.
     show:
       back_to_ideas: Back to Ideas
+      comments_locked: Locked
+      lock_discussion: Lock discussion
       pin: Pin
       pinned: Pinned
       share: Share
+      unlock_discussion: Unlock discussion
       unpin: Unpin
       watch: Watch
     statuses:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -583,11 +583,10 @@ en:
         unlocked: Discussion has been unlocked.
     comments:
       create:
+        comments_locked: Discussion is locked.
         successfully_created: Comment was successfully created.
       destroy:
         successfully_destroyed: Comment was successfully deleted.
-      ensure_comments_not_locked:
-        comments_locked: Discussion is locked.
       update:
         successfully_updated: Comment was successfully updated.
       votes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
       resource :vote, only: [ :update ]
       resource :watch, only: [ :show, :create, :destroy ]
       resource :pin, only: [ :create, :destroy ]
+      resource :comment_lock, only: [ :create, :destroy ]
       resource :status, only: [ :update ]
       resources :taggings, only: [ :new, :create, :destroy ]
 

--- a/db/migrate/20260329000000_add_comments_locked_to_ideas.rb
+++ b/db/migrate/20260329000000_add_comments_locked_to_ideas.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCommentsLockedToIdeas < ActiveRecord::Migration[8.2]
+  def change
+    add_column :ideas, :comments_locked, :boolean, default: false, null: false
+    add_index :ideas, :comments_locked
+  end
+end

--- a/db/migrate/20260329000000_add_is_comments_locked_to_ideas.rb
+++ b/db/migrate/20260329000000_add_is_comments_locked_to_ideas.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class AddIsCommentsLockedToIdeas < ActiveRecord::Migration[8.2]
-  def change
-    add_column :ideas, :is_comments_locked, :boolean, default: false, null: false
-    add_index :ideas, :is_comments_locked
-  end
-end

--- a/db/migrate/20260329000000_add_is_comments_locked_to_ideas.rb
+++ b/db/migrate/20260329000000_add_is_comments_locked_to_ideas.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddIsCommentsLockedToIdeas < ActiveRecord::Migration[8.2]
+  def change
+    add_column :ideas, :is_comments_locked, :boolean, default: false, null: false
+    add_index :ideas, :is_comments_locked
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -134,10 +134,10 @@ ActiveRecord::Schema[8.2].define(version: 2026_03_29_000001) do
     t.bigint "account_id", null: false
     t.integer "board_id", null: false
     t.integer "comments_count", default: 0, null: false
+    t.boolean "comments_locked", default: false, null: false
     t.datetime "created_at", null: false
     t.bigint "creator_id", null: false
     t.bigint "official_comment_id"
-    t.boolean "is_comments_locked", default: false, null: false
     t.boolean "pinned", default: false, null: false
     t.integer "status_id"
     t.string "title", null: false
@@ -145,9 +145,9 @@ ActiveRecord::Schema[8.2].define(version: 2026_03_29_000001) do
     t.integer "votes_count", default: 0, null: false
     t.index ["account_id"], name: "index_ideas_on_account_id"
     t.index ["board_id"], name: "index_ideas_on_board_id"
+    t.index ["comments_locked"], name: "index_ideas_on_comments_locked"
     t.index ["creator_id"], name: "index_ideas_on_creator_id"
     t.index ["official_comment_id"], name: "index_ideas_on_official_comment_id"
-    t.index ["is_comments_locked"], name: "index_ideas_on_is_comments_locked"
     t.index ["pinned"], name: "index_ideas_on_pinned"
     t.index ["status_id"], name: "index_ideas_on_status_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -137,6 +137,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_03_29_000001) do
     t.datetime "created_at", null: false
     t.bigint "creator_id", null: false
     t.bigint "official_comment_id"
+    t.boolean "is_comments_locked", default: false, null: false
     t.boolean "pinned", default: false, null: false
     t.integer "status_id"
     t.string "title", null: false
@@ -146,6 +147,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_03_29_000001) do
     t.index ["board_id"], name: "index_ideas_on_board_id"
     t.index ["creator_id"], name: "index_ideas_on_creator_id"
     t.index ["official_comment_id"], name: "index_ideas_on_official_comment_id"
+    t.index ["is_comments_locked"], name: "index_ideas_on_is_comments_locked"
     t.index ["pinned"], name: "index_ideas_on_pinned"
     t.index ["status_id"], name: "index_ideas_on_status_id"
   end

--- a/test/controllers/ideas/comment_locks_controller_test.rb
+++ b/test/controllers/ideas/comment_locks_controller_test.rb
@@ -16,11 +16,11 @@ class Ideas::CommentLocksControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to idea_url(@idea)
     assert_equal I18n.t("ideas.comment_locks.create.locked"), flash[:notice]
 
-    assert @idea.reload.is_comments_locked?
+    assert_predicate @idea.reload, :comments_locked?
   end
 
   test "admin can unlock discussion" do
-    @idea.update!(is_comments_locked: true)
+    @idea.update!(comments_locked: true)
     sign_in_as users(:admin)
 
     delete idea_comment_lock_url(@idea)
@@ -29,7 +29,7 @@ class Ideas::CommentLocksControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to idea_url(@idea)
     assert_equal I18n.t("ideas.comment_locks.destroy.unlocked"), flash[:notice]
 
-    assert_not @idea.reload.is_comments_locked?
+    assert_not @idea.reload.comments_locked?
   end
 
   test "owner can lock discussion" do
@@ -38,7 +38,7 @@ class Ideas::CommentLocksControllerTest < ActionDispatch::IntegrationTest
     post idea_comment_lock_url(@idea)
 
     assert_response :redirect
-    assert @idea.reload.is_comments_locked?
+    assert_predicate @idea.reload, :comments_locked?
   end
 
   test "regular member cannot lock discussion" do
@@ -46,14 +46,14 @@ class Ideas::CommentLocksControllerTest < ActionDispatch::IntegrationTest
 
     post idea_comment_lock_url(@idea)
 
-    assert_response :redirect
-    assert_not @idea.reload.is_comments_locked?
+    assert_response :forbidden
+    assert_not @idea.reload.comments_locked?
   end
 
   test "unauthenticated user cannot lock discussion" do
     post idea_comment_lock_url(@idea)
 
     assert_response :redirect
-    assert_not @idea.reload.is_comments_locked?
+    assert_not @idea.reload.comments_locked?
   end
 end

--- a/test/controllers/ideas/comment_locks_controller_test.rb
+++ b/test/controllers/ideas/comment_locks_controller_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Ideas::CommentLocksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @idea = ideas(:one)
+  end
+
+  test "admin can lock discussion" do
+    sign_in_as users(:admin)
+
+    post idea_comment_lock_url(@idea)
+
+    assert_response :redirect
+    assert_redirected_to idea_url(@idea)
+    assert_equal I18n.t("ideas.comment_locks.create.locked"), flash[:notice]
+
+    assert @idea.reload.is_comments_locked?
+  end
+
+  test "admin can unlock discussion" do
+    @idea.update!(is_comments_locked: true)
+    sign_in_as users(:admin)
+
+    delete idea_comment_lock_url(@idea)
+
+    assert_response :redirect
+    assert_redirected_to idea_url(@idea)
+    assert_equal I18n.t("ideas.comment_locks.destroy.unlocked"), flash[:notice]
+
+    assert_not @idea.reload.is_comments_locked?
+  end
+
+  test "owner can lock discussion" do
+    sign_in_as users(:shane)
+
+    post idea_comment_lock_url(@idea)
+
+    assert_response :redirect
+    assert @idea.reload.is_comments_locked?
+  end
+
+  test "regular member cannot lock discussion" do
+    sign_in_as users(:jane)
+
+    post idea_comment_lock_url(@idea)
+
+    assert_response :redirect
+    assert_not @idea.reload.is_comments_locked?
+  end
+
+  test "unauthenticated user cannot lock discussion" do
+    post idea_comment_lock_url(@idea)
+
+    assert_response :redirect
+    assert_not @idea.reload.is_comments_locked?
+  end
+end

--- a/test/controllers/ideas/comments_controller_test.rb
+++ b/test/controllers/ideas/comments_controller_test.rb
@@ -94,4 +94,39 @@ class Ideas::CommentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :forbidden
   end
+
+  test "should not create comment on locked idea for regular user" do
+    locked_idea = ideas(:locked)
+    sign_in_as users(:jane)
+
+    assert_no_difference "Comment.count" do
+      post idea_comments_url(locked_idea), params: { comment: { body: "Hello!" } }
+    end
+
+    assert_response :redirect
+    assert_redirected_to idea_url(locked_idea)
+    assert_equal I18n.t("ideas.comments.create.comments_locked"), flash[:alert]
+  end
+
+  test "admin can comment on locked idea" do
+    locked_idea = ideas(:locked)
+    sign_in_as users(:admin)
+
+    assert_difference "Comment.count" do
+      post idea_comments_url(locked_idea), params: { comment: { body: "Admin comment on locked idea" } }
+    end
+
+    assert_response :redirect
+  end
+
+  test "owner can comment on locked idea" do
+    locked_idea = ideas(:locked)
+    sign_in_as users(:shane)
+
+    assert_difference "Comment.count" do
+      post idea_comments_url(locked_idea), params: { comment: { body: "Owner comment on locked idea" } }
+    end
+
+    assert_response :redirect
+  end
 end

--- a/test/fixtures/ideas.yml
+++ b/test/fixtures/ideas.yml
@@ -26,5 +26,5 @@ locked:
   title: This idea has comments locked
   creator: shane
   board: one
-  is_comments_locked: true
+  comments_locked: true
 

--- a/test/fixtures/ideas.yml
+++ b/test/fixtures/ideas.yml
@@ -21,3 +21,10 @@ three:
   board: two
   status: in_progress
 
+locked:
+  account: feedbackbin
+  title: This idea has comments locked
+  creator: shane
+  board: one
+  is_comments_locked: true
+

--- a/test/models/idea/participants_test.rb
+++ b/test/models/idea/participants_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class Idea::ParticipantsTest < ActiveSupport::TestCase
-  def setup
+  setup do
     Current.session = sessions(:shane_chrome)
   end
 

--- a/test/models/idea_test.rb
+++ b/test/models/idea_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class IdeaTest < ActiveSupport::TestCase
-  def setup
+  setup do
     Current.session = sessions(:shane_chrome)
     @idea = ideas(:one)
   end
@@ -132,6 +132,7 @@ class IdeaTest < ActiveSupport::TestCase
     assert_raises(ArgumentError) do
       @idea.clear_official_response!(actor: users(:jane))
     end
+  end
 
   test "comments_locked defaults to false" do
     idea = Idea.create!(

--- a/test/models/idea_test.rb
+++ b/test/models/idea_test.rb
@@ -132,25 +132,28 @@ class IdeaTest < ActiveSupport::TestCase
     assert_raises(ArgumentError) do
       @idea.clear_official_response!(actor: users(:jane))
     end
-  test "is_comments_locked defaults to false" do
+
+  test "comments_locked defaults to false" do
     idea = Idea.create!(
       title: "Test",
       creator: users(:shane),
       board: boards(:one)
     )
 
-    assert_not idea.is_comments_locked?
+    assert_not idea.comments_locked?
   end
 
   test "can lock and unlock comments" do
     idea = ideas(:one)
 
-    assert_not idea.is_comments_locked?
+    assert_not idea.comments_locked?
 
-    idea.update!(is_comments_locked: true)
-    assert idea.is_comments_locked?
+    idea.update!(comments_locked: true)
 
-    idea.update!(is_comments_locked: false)
-    assert_not idea.is_comments_locked?
+    assert_predicate idea, :comments_locked?
+
+    idea.update!(comments_locked: false)
+
+    assert_not idea.comments_locked?
   end
 end

--- a/test/models/idea_test.rb
+++ b/test/models/idea_test.rb
@@ -132,5 +132,25 @@ class IdeaTest < ActiveSupport::TestCase
     assert_raises(ArgumentError) do
       @idea.clear_official_response!(actor: users(:jane))
     end
+  test "is_comments_locked defaults to false" do
+    idea = Idea.create!(
+      title: "Test",
+      creator: users(:shane),
+      board: boards(:one)
+    )
+
+    assert_not idea.is_comments_locked?
+  end
+
+  test "can lock and unlock comments" do
+    idea = ideas(:one)
+
+    assert_not idea.is_comments_locked?
+
+    idea.update!(is_comments_locked: true)
+    assert idea.is_comments_locked?
+
+    idea.update!(is_comments_locked: false)
+    assert_not idea.is_comments_locked?
   end
 end

--- a/test/models/identity_test.rb
+++ b/test/models/identity_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class IdentityTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @identity = identities(:jane)
   end
 

--- a/test/models/session_test.rb
+++ b/test/models/session_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class SessionTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @session = sessions(:shane_chrome)
   end
 

--- a/test/models/status_test.rb
+++ b/test/models/status_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class StatusTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @status = statuses(:complete)
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @user = users(:jane)
   end
 

--- a/test/models/vote_test.rb
+++ b/test/models/vote_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class VoteTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @vote = votes(:one)
   end
 


### PR DESCRIPTION
Adds the ability for admins/owners to lock discussion on an idea,
preventing non-admin users from posting new comments or replies while
keeping existing comments visible. Admins can still comment on locked ideas.

- Migration: adds is_comments_locked boolean column (default false) with index
- CommentLocksController: POST/DELETE to lock/unlock (admin-only)
- Comments controller: blocks comment creation for non-admins on locked ideas
- Idea show: lock badge, lock/unlock dropdown item for admins
- Comment form: shows "Discussion is locked" message to non-admins when locked
- Comment partial: hides reply form for non-admins when locked
- Turbo stream templates for live lock/unlock UI updates
- I18n translations for all new UI copy
- Tests: model defaults, lock/unlock permissions, comment creation policy

https://claude.ai/code/session_01AsPFqQuqw5SCQGDBA4Txef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can lock/unlock idea discussions to prevent new comments.
  * Locked ideas show a lock badge and lock/unlock controls in the idea UI.
  * Comment form and reply options are hidden for non-admins when locked; admins still see comment controls.

* **Localization**
  * Added messaging for locked/unlocked states and action buttons.

* **Tests**
  * New tests cover lock/unlock behavior and commenting restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->