### PR TITLE
Route OmniAuth logger to Rails.logger

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+OmniAuth.config.logger = Rails.logger
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :developer if Oauth::Providers.available.include?("developer")
 


### PR DESCRIPTION
Before, OmniAuth had no logger configured, so it defaulted to writing
to STDOUT. The "should handle invalid credentials" test in
Users::OmniauthControllerTest exercises the auth-failure path, which
causes OmniAuth to log an ERROR line. That line then surfaced in the
test runner output alongside the dots, making it harder to spot any
genuinely unexpected output.

Now, OmniAuth's logger is wired to Rails.logger, so its messages flow
into log/test.log (and log/development.log, log/production.log) along
with the rest of the app's logs instead of leaking into the test
output stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced authentication logging configuration for improved system observability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/murny/feedbackbin/pull/960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->