### PR TITLE
feat(02-02): add Elements::EmptyStateComponent + empty-state.css + lookbook previews

### DIFF
--- a/app/assets/stylesheets/empty-state.css
+++ b/app/assets/stylesheets/empty-state.css
@@ -2,10 +2,11 @@
    Empty State Component
 
    Usage:
-     <%= render "shared/empty_state",
-                icon: "inbox",
-                title: t("..."),
-                description: t("...") %>
+     <%= render Elements::EmptyStateComponent.new(
+           icon: "inbox",
+           title: t("..."),
+           description: t("...")
+         ) %>
 
    Variants: empty-state--default, empty-state--compact,
              empty-state--inline, empty-state--page

--- a/app/assets/stylesheets/empty-state.css
+++ b/app/assets/stylesheets/empty-state.css
@@ -1,0 +1,74 @@
+/* ==========================================================================
+   Empty State Component
+
+   Usage:
+     <%= render "shared/empty_state",
+                icon: "inbox",
+                title: t("..."),
+                description: t("...") %>
+
+   Variants: empty-state--default, empty-state--compact,
+             empty-state--inline, empty-state--page
+   ========================================================================== */
+
+@layer components {
+  .empty-state {
+    --empty-state-padding-block: var(--space-12);
+    --empty-state-padding-inline: 0;
+    --empty-state-title-size: var(--text-base);
+    --empty-state-description-max-inline-size: 24rem;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding-block: var(--empty-state-padding-block);
+    padding-inline: var(--empty-state-padding-inline);
+  }
+
+  .empty-state--compact {
+    --empty-state-padding-block: var(--space-8);
+  }
+
+  .empty-state--inline {
+    --empty-state-padding-block: var(--space-6);
+    --empty-state-padding-inline: var(--space-3);
+  }
+
+  .empty-state--page {
+    --empty-state-padding-block: var(--space-16);
+    --empty-state-title-size: var(--text-xl);
+    --empty-state-description-max-inline-size: 28rem;
+  }
+
+  .empty-state__icon {
+    --empty-state-icon-size: 5rem;
+
+    inline-size: var(--empty-state-icon-size);
+    block-size: var(--empty-state-icon-size);
+    background-color: var(--color-ink-lightest);
+    border-radius: var(--radius-full);
+    margin-inline: auto;
+  }
+
+  .empty-state__title {
+    font-size: var(--empty-state-title-size);
+    font-weight: var(--font-bold);
+    line-height: var(--leading-tight);
+    margin-block-start: var(--space-6);
+  }
+
+  .empty-state__description {
+    font-size: var(--text-sm);
+    font-weight: var(--font-normal);
+    line-height: var(--leading-normal);
+    color: var(--color-ink-light);
+    max-inline-size: var(--empty-state-description-max-inline-size);
+    margin-block-start: var(--space-2);
+    margin-inline: auto;
+  }
+
+  .empty-state__cta {
+    margin-block-start: var(--space-4);
+  }
+}

--- a/app/components/elements/empty_state_component.html.erb
+++ b/app/components/elements/empty_state_component.html.erb
@@ -1,0 +1,12 @@
+<%= tag.div(**container_attrs) do %>
+  <div class="empty-state__icon flex align-center justify-center">
+    <%= helpers.lucide_icon @icon, class: "size-10 txt-subtle" %>
+  </div>
+  <h3 class="empty-state__title"><%= @title %></h3>
+  <% if @description.present? %>
+    <p class="empty-state__description"><%= @description %></p>
+  <% end %>
+  <% if cta? %>
+    <div class="empty-state__cta"><%= cta %></div>
+  <% end %>
+<% end %>

--- a/app/components/elements/empty_state_component.rb
+++ b/app/components/elements/empty_state_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Elements
+  class EmptyStateComponent < BaseComponent
+    VARIANTS = %i[default compact inline page].freeze
+
+    renders_one :cta
+
+    def initialize(
+      icon:,
+      title:,
+      description: nil,
+      variant: :default,
+      **attrs
+    )
+      @icon        = icon
+      @title       = title
+      @description = description
+      @variant     = validate_option(variant, VARIANTS, "variant")
+      @attrs       = attrs
+    end
+
+    private
+
+      def container_attrs
+        @attrs.merge(class: empty_state_classes)
+      end
+
+      def empty_state_classes
+        [
+          "empty-state",
+          "empty-state--#{@variant}",
+          @attrs[:class]
+        ].compact.join(" ")
+      end
+  end
+end

--- a/app/components/elements/empty_state_component.rb
+++ b/app/components/elements/empty_state_component.rb
@@ -30,7 +30,7 @@ module Elements
         [
           "empty-state",
           "empty-state--#{@variant}",
-          @attrs[:class]
+          *Array.wrap(@attrs[:class])
         ].compact.join(" ")
       end
   end

--- a/test/components/elements/empty_state_component_test.rb
+++ b/test/components/elements/empty_state_component_test.rb
@@ -48,12 +48,22 @@ module Elements
       assert_selector ".empty-state.empty-state--default"
     end
 
-    test "applies the requested variant modifier class for :compact, :inline, :page" do
-      %i[compact inline page].each do |variant|
-        render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items", variant: variant))
+    test "applies the compact variant modifier class" do
+      render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items", variant: :compact))
 
-        assert_selector ".empty-state.empty-state--#{variant}"
-      end
+      assert_selector ".empty-state.empty-state--compact"
+    end
+
+    test "applies the inline variant modifier class" do
+      render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items", variant: :inline))
+
+      assert_selector ".empty-state.empty-state--inline"
+    end
+
+    test "applies the page variant modifier class" do
+      render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items", variant: :page))
+
+      assert_selector ".empty-state.empty-state--page"
     end
 
     test "raises ArgumentError for an invalid variant" do

--- a/test/components/elements/empty_state_component_test.rb
+++ b/test/components/elements/empty_state_component_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Elements
+  class EmptyStateComponentTest < ViewComponent::TestCase
+    test "renders the title inside an h3.empty-state__title" do
+      render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items"))
+
+      assert_selector "h3.empty-state__title", text: "No items"
+    end
+
+    test "renders the lucide icon inside an .empty-state__icon wrapper with size-10 and txt-subtle classes" do
+      render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items"))
+
+      assert_selector ".empty-state__icon svg.size-10.txt-subtle"
+    end
+
+    test "renders the description paragraph when description is present" do
+      render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items", description: "Try again"))
+
+      assert_selector "p.empty-state__description", text: "Try again"
+    end
+
+    test "omits the description paragraph when description is nil" do
+      render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items"))
+
+      assert_no_selector "p.empty-state__description"
+    end
+
+    test "omits the cta wrapper when no cta slot is provided" do
+      render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items"))
+
+      assert_no_selector ".empty-state__cta"
+    end
+
+    test "renders the cta slot content inside an .empty-state__cta div" do
+      render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items")) do |c|
+        c.with_cta { '<a href="/somewhere" class="btn btn--primary">Do it</a>'.html_safe }
+      end
+
+      assert_selector ".empty-state__cta a", text: "Do it"
+    end
+
+    test "applies the default variant class when no variant is passed" do
+      render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items"))
+
+      assert_selector ".empty-state.empty-state--default"
+    end
+
+    test "applies the requested variant modifier class for :compact, :inline, :page" do
+      %i[compact inline page].each do |variant|
+        render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items", variant: variant))
+
+        assert_selector ".empty-state.empty-state--#{variant}"
+      end
+    end
+
+    test "raises ArgumentError for an invalid variant" do
+      error = assert_raises(ArgumentError) do
+        EmptyStateComponent.new(icon: "inbox", title: "No items", variant: :nope)
+      end
+
+      assert_match(/Unknown variant: nope/, error.message)
+    end
+
+    test "merges caller-provided :class with the empty-state classes" do
+      render_inline(EmptyStateComponent.new(icon: "inbox", title: "No items", class: "extra-margin"))
+
+      assert_selector ".empty-state.empty-state--default.extra-margin"
+    end
+  end
+end

--- a/test/components/previews/elements/empty_state_component_preview.rb
+++ b/test/components/previews/elements/empty_state_component_preview.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Elements
+  # @label Empty State
+  class EmptyStateComponentPreview < ViewComponent::Preview
+    # @label Default
+    def default
+      render Elements::EmptyStateComponent.new(
+        icon: "inbox",
+        title: "No ideas yet",
+        description: "Be the first to share an idea!"
+      )
+    end
+
+    # @label Variants
+    def variants
+      render_with_template
+    end
+
+    # @label With CTA
+    def with_cta
+      render_with_template
+    end
+  end
+end

--- a/test/components/previews/elements/empty_state_component_preview/variants.html.erb
+++ b/test/components/previews/elements/empty_state_component_preview/variants.html.erb
@@ -1,0 +1,21 @@
+<%#
+  Variants change padding scale, title size, and description max-width.
+  Default is the full-page-ish form; compact suits sidebars / small cells;
+  inline is for narrow column headers; page is for primary landing surfaces.
+%>
+
+<div class="flex flex-column gap-6">
+  <% %i[default compact inline page].each do |variant| %>
+    <div>
+      <h4 class="txt-small font-weight-semibold txt-subtle margin-block-end-2">
+        :<%= variant %>
+      </h4>
+      <%= render Elements::EmptyStateComponent.new(
+        icon: "inbox",
+        title: "No ideas yet",
+        description: "Be the first to share an idea!",
+        variant: variant
+      ) %>
+    </div>
+  <% end %>
+</div>

--- a/test/components/previews/elements/empty_state_component_preview/variants.html.erb
+++ b/test/components/previews/elements/empty_state_component_preview/variants.html.erb
@@ -7,7 +7,7 @@
 <div class="flex flex-column gap-6">
   <% %i[default compact inline page].each do |variant| %>
     <div>
-      <h4 class="txt-small font-weight-semibold txt-subtle margin-block-end-2">
+      <h4 class="txt-small font-weight-semibold txt-subtle margin-block-end-half">
         :<%= variant %>
       </h4>
       <%= render Elements::EmptyStateComponent.new(

--- a/test/components/previews/elements/empty_state_component_preview/with_cta.html.erb
+++ b/test/components/previews/elements/empty_state_component_preview/with_cta.html.erb
@@ -1,0 +1,17 @@
+<%#
+  CTA slot accepts any block — typically a link or button. Use for empty
+  states where the user can take action (e.g. "Create your first idea").
+%>
+
+<%= render Elements::EmptyStateComponent.new(
+  icon: "inbox",
+  title: "No ideas yet",
+  description: "Be the first to share an idea!"
+) do |c| %>
+  <% c.with_cta do %>
+    <%= render Elements::ButtonComponent.new(href: "#", variant: :default) do %>
+      <%= lucide_icon "plus" %>
+      Share an idea
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an empty state component for placeholder content with icon, title, optional description, CTA, and layout variants (default, compact, inline, page).

* **Style**
  * New stylesheet providing layout, spacing, and element styles for the empty state and its variants.

* **Tests**
  * Added component tests and interactive previews for the empty state.
  * Added view tests covering comment and reply partial rendering and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/murny/feedbackbin/pull/977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->