### PR TITLE
refactor(02-05): extract shared comments/comment/_header + _body sub-partials

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -21,65 +21,13 @@
             <%= render partial: "votes/vote_button", locals: { voteable: comment } %>
           </div>
           <div class="flex-1 min-width">
-            <div class="flex justify-space-between align-center margin-block-end-half">
-              <div class="flex align-center">
-                <%= avatar_tag comment.creator, class: "avatar avatar--sm", alt: comment.creator.name, style: "margin-inline-end: var(--space-2);" %>
-
-                <p class="flex-inline flex-column align-start margin-inline-end txt-small txt-ink">
-                  <span class="font-weight-bold"><%= comment.creator.name %></span>
-                  <%= link_to idea_path(comment.idea, anchor: dom_id(comment)), class: "txt-small txt-subtle txt-underline", data: { turbo_frame: "_top" } do %>
-                    <%= local_datetime_tag comment.created_at, style: :datetime %>
-                  <% end %>
-                </p>
-              </div>
-              <%= render Elements::DropdownMenuComponent.new do |dropdown| %>
-                <% dropdown.with_trigger(variant: :ghost, size: :icon, class: "txt-subtle") do %>
-                  <%= lucide_icon("ellipsis") %>
-                  <span class="visually-hidden"><%= t(".comment_settings") %></span>
-                <% end %>
-
-                <% if Current.user&.can_administer_comment?(comment) %>
-                  <% dropdown.with_item_content(href: edit_idea_comment_path(comment.idea, comment)) do %>
-                    <%= t("edit") %>
-                  <% end %>
-                  <% dropdown.with_item_content(
-                    href: idea_comment_path(comment.idea, comment),
-                    method: :delete,
-                    form: { data: { turbo_confirm: t("are_you_sure") } }
-                  ) do %>
-                    <%= t("remove") %>
-                  <% end %>
-                <% end %>
-
-                <% dropdown.with_item_content(
-                  href: "#",
-                  data: {
-                    controller: "copy-to-clipboard",
-                    copy_to_clipboard_content_value: idea_url(comment.idea, anchor: dom_id(comment)),
-                    action: "click->copy-to-clipboard#copy"
-                  }
-                ) do %>
-                  <%= t(".copy_link") %>
-                <% end %>
-
-                <% dropdown.with_item_content(href: "#") do %>
-                  <%= t("report") %>
-                <% end %>
-              <% end %>
-            </div>
-            <div class="txt-subtle" data-controller="syntax-highlight">
-              <%= comment.body %>
-            </div>
-
-            <div class="margin-block-start-half flex align-center justify-space-between gap">
-              <%= render "reactions/reactions", reactable: comment %>
-
-              <% if comment.replies.any? %>
-                <span class="txt-small txt-subtle">
-                  <%= t(".replies_count", count: comment.replies.size) %>
-                </span>
-              <% end %>
-            </div>
+            <%= render "comments/comment/header",
+                       comment: comment,
+                       timestamp_size: :small,
+                       trigger_label: t("comments.comment.comment_settings") %>
+            <%= render "comments/comment/body",
+                       comment: comment,
+                       replies_summary: true %>
           </div>
         </div>
       </div>

--- a/app/views/comments/_reply.html.erb
+++ b/app/views/comments/_reply.html.erb
@@ -3,71 +3,28 @@
 <%= turbo_frame_tag reply, class: "display-block", style: "scroll-margin-block-start: var(--space-4);" do %>
   <div class="reply-thread">
     <div class="flex-1 min-width">
-      <div class="flex justify-space-between align-center margin-block-end-half">
-        <div class="flex align-center">
-          <%= avatar_tag reply.creator, class: "avatar avatar--sm", alt: reply.creator.name, style: "margin-inline-end: var(--space-2);" %>
-
-          <p class="flex-inline flex-column align-start margin-inline-end txt-small txt-ink">
-            <span class="font-weight-medium"><%= reply.creator.name %></span>
-            <%= link_to idea_path(reply.idea, anchor: dom_id(reply)), class: "txt-x-small txt-subtle txt-underline", data: { turbo_frame: "_top" } do %>
-              <%= local_datetime_tag reply.created_at, style: :datetime %>
-            <% end %>
-          </p>
-        </div>
-        <%= render Elements::DropdownMenuComponent.new do |dropdown| %>
-          <% dropdown.with_trigger(variant: :ghost, size: :icon, class: "txt-subtle") do %>
-            <%= lucide_icon("ellipsis") %>
-            <span class="visually-hidden"><%= t(".reply_settings") %></span>
-          <% end %>
-
-          <% if Current.user&.can_administer_comment?(reply) %>
-            <% dropdown.with_item_content(href: edit_idea_comment_path(reply.idea, reply)) do %>
-              <%= t("edit") %>
-            <% end %>
-            <% dropdown.with_item_content(
-              href: idea_comment_path(reply.idea, reply),
-              method: :delete,
-              form: { data: { turbo_confirm: t("are_you_sure") } }
-            ) do %>
-              <%= t("remove") %>
-            <% end %>
-          <% end %>
-
-          <% dropdown.with_item_content(
-            href: "#",
-            data: {
-              controller: "copy-to-clipboard",
-              copy_to_clipboard_content_value: idea_url(reply.idea, anchor: dom_id(reply)),
-              action: "click->copy-to-clipboard#copy"
-            }
-          ) do %>
-            <%= t(".copy_link") %>
-          <% end %>
-
-          <% dropdown.with_item_content(
-            href: "#",
-            data: {
-              controller: "quote-reply",
-              quote_reply_text_value: reply.body.to_plain_text,
-              quote_reply_form_id_value: "#{dom_id(reply.parent)}_reply_form",
-              action: "click->quote-reply#quote"
-            }
-          ) do %>
-            <%= t(".quote_reply") %>
-          <% end %>
-
-          <% dropdown.with_item_content(href: "#") do %>
-            <%= t("report") %>
-          <% end %>
+      <%= render "comments/comment/header",
+                 comment: reply,
+                 timestamp_size: :x_small,
+                 trigger_label: t("comments.reply.reply_settings"),
+                 copy_link_label: t("comments.reply.copy_link") do |dropdown| %>
+        <% dropdown.with_item_content(
+          href: "#",
+          data: {
+            controller: "quote-reply",
+            quote_reply_text_value: reply.body.to_plain_text,
+            quote_reply_form_id_value: "#{dom_id(reply.parent)}_reply_form",
+            action: "click->quote-reply#quote"
+          }
+        ) do %>
+          <%= t("comments.reply.quote_reply") %>
         <% end %>
-      </div>
+      <% end %>
 
-      <div class="txt-small txt-subtle" data-controller="syntax-highlight">
-        <%= reply.body %>
-      </div>
-
-      <div class="margin-block-start-half">
-        <%= render "reactions/reactions", reactable: reply %>
+      <div class="txt-small">
+        <%= render "comments/comment/body",
+                   comment: reply,
+                   replies_summary: false %>
       </div>
     </div>
   </div>

--- a/app/views/comments/comment/_body.html.erb
+++ b/app/views/comments/comment/_body.html.erb
@@ -1,0 +1,14 @@
+<%# locals: (comment:, replies_summary: false) %>
+<div class="txt-subtle" data-controller="syntax-highlight">
+  <%= comment.body %>
+</div>
+
+<div class="margin-block-start-half flex align-center justify-space-between gap">
+  <%= render "reactions/reactions", reactable: comment %>
+
+  <% if replies_summary && comment.replies.any? %>
+    <span class="txt-small txt-subtle">
+      <%= t("comments.comment.replies_count", count: comment.replies.size) %>
+    </span>
+  <% end %>
+</div>

--- a/app/views/comments/comment/_header.html.erb
+++ b/app/views/comments/comment/_header.html.erb
@@ -1,0 +1,50 @@
+<%# locals: (comment:, timestamp_size: :small, trigger_label:, copy_link_label: nil) %>
+<% copy_link_label ||= t("comments.comment.copy_link") %>
+<div class="flex justify-space-between align-center margin-block-end-half">
+  <div class="flex align-center">
+    <%= avatar_tag comment.creator, class: "avatar avatar--sm", alt: comment.creator.name, style: "margin-inline-end: var(--space-2);" %>
+
+    <p class="flex-inline flex-column align-start margin-inline-end txt-small txt-ink">
+      <span class="font-weight-bold"><%= comment.creator.name %></span>
+      <%= link_to idea_path(comment.idea, anchor: dom_id(comment)), class: "txt-#{timestamp_size} txt-subtle txt-underline", data: { turbo_frame: "_top" } do %>
+        <%= local_datetime_tag comment.created_at, style: :datetime %>
+      <% end %>
+    </p>
+  </div>
+  <%= render Elements::DropdownMenuComponent.new do |dropdown| %>
+    <% dropdown.with_trigger(variant: :ghost, size: :icon, class: "txt-subtle") do %>
+      <%= lucide_icon("ellipsis") %>
+      <span class="visually-hidden"><%= trigger_label %></span>
+    <% end %>
+
+    <% if Current.user&.can_administer_comment?(comment) %>
+      <% dropdown.with_item_content(href: edit_idea_comment_path(comment.idea, comment)) do %>
+        <%= t("edit") %>
+      <% end %>
+      <% dropdown.with_item_content(
+        href: idea_comment_path(comment.idea, comment),
+        method: :delete,
+        form: { data: { turbo_confirm: t("are_you_sure") } }
+      ) do %>
+        <%= t("remove") %>
+      <% end %>
+    <% end %>
+
+    <% dropdown.with_item_content(
+      href: "#",
+      data: {
+        controller: "copy-to-clipboard",
+        copy_to_clipboard_content_value: idea_url(comment.idea, anchor: dom_id(comment)),
+        action: "click->copy-to-clipboard#copy"
+      }
+    ) do %>
+      <%= copy_link_label %>
+    <% end %>
+
+    <% yield dropdown if block_given? %>
+
+    <% dropdown.with_item_content(href: "#") do %>
+      <%= t("report") %>
+    <% end %>
+  <% end %>
+</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized comment and reply view templates to use dedicated header and body partials for improved modularity.
  * Added syntax highlighting to comment bodies and integrated reaction rendering into comment display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/murny/feedbackbin/pull/981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->