### PR TITLE
test(02-07): assert EmptyStateComponent renders in admin/ideas + admin/users empty branches 

### DIFF
--- a/app/views/admin/changelogs/index.html.erb
+++ b/app/views/admin/changelogs/index.html.erb
@@ -85,13 +85,16 @@
     <% end %>
   <% else %>
     <%= render Elements::PanelComponent.new do |c| %>
-      <% c.with_body(class: "txt-align-center", style: "padding: var(--space-8);") do %>
-        <%= lucide_icon "megaphone", class: "size-12 txt-subtle center" %>
-        <h3 class="txt-medium font-weight-bold margin-block-start"><%= t(".no_changelogs_title") %></h3>
-        <p class="txt-small txt-subtle margin-block-start-half"><%= t(".no_changelogs_description") %></p>
-        <div style="margin-block-start: var(--space-6);">
-          <%= link_to t(".create_first_changelog"), new_admin_changelog_path, class: "btn btn--primary" %>
-        </div>
+      <% c.with_body do %>
+        <%= render Elements::EmptyStateComponent.new(
+              icon: "megaphone",
+              title: t(".no_changelogs_title"),
+              description: t(".no_changelogs_description")
+            ) do |empty| %>
+          <% empty.with_cta do %>
+            <%= link_to t(".create_first_changelog"), new_admin_changelog_path, class: "btn btn--primary" %>
+          <% end %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/admin/ideas/_ideas_list.html.erb
+++ b/app/views/admin/ideas/_ideas_list.html.erb
@@ -84,18 +84,13 @@
           <% end %>
         <% else %>
           <tr>
-            <td colspan="5" class="txt-align-center" style="padding-inline: var(--space-6); padding-block: var(--space-12);">
-              <div class="center size-12 fill-shade flex align-center justify-center" style="margin-block-end: var(--space-4); border-radius: 9999px;">
-                <%= lucide_icon "message-square", class: "size-6 txt-subtle" %>
-              </div>
-              <h3 class="txt-small font-weight-medium margin-block-end-half"><%= t(".no_ideas_title") %></h3>
-              <p class="txt-small txt-subtle">
-                <% if params[:search].present? %>
-                  <%= t(".no_ideas_search") %>
-                <% else %>
-                  <%= t(".no_ideas_empty") %>
-                <% end %>
-              </p>
+            <td colspan="5">
+              <%= render Elements::EmptyStateComponent.new(
+                    icon: "message-square",
+                    title: t(".no_ideas_title"),
+                    description: (params[:search].present? ? t(".no_ideas_search") : t(".no_ideas_empty")),
+                    variant: :compact
+                  ) %>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/invitations/_invitations_list.html.erb
+++ b/app/views/admin/invitations/_invitations_list.html.erb
@@ -57,11 +57,11 @@
     </ul>
   </div>
 <% else %>
-  <div class="panel txt-align-center" style="padding: var(--space-8);">
-    <%= lucide_icon "mail-check", class: "center txt-subtle", style: "inline-size: 3rem; block-size: 3rem;" %>
-    <h3 class="txt-large font-weight-semibold margin-block-start"><%= t(".no_invitations_title") %></h3>
-    <p class="txt-small txt-subtle margin-block-start-half"><%= t(".no_invitations_description") %></p>
-  </div>
+  <%= render Elements::EmptyStateComponent.new(
+        icon: "mail-check",
+        title: t(".no_invitations_title"),
+        description: t(".no_invitations_description")
+      ) %>
 <% end %>
 
 <% if pagy.last > 1 %>

--- a/app/views/admin/invitations/_invitations_list.html.erb
+++ b/app/views/admin/invitations/_invitations_list.html.erb
@@ -57,11 +57,15 @@
     </ul>
   </div>
 <% else %>
-  <%= render Elements::EmptyStateComponent.new(
-        icon: "mail-check",
-        title: t(".no_invitations_title"),
-        description: t(".no_invitations_description")
-      ) %>
+  <%= render Elements::PanelComponent.new do |c| %>
+    <% c.with_body do %>
+      <%= render Elements::EmptyStateComponent.new(
+            icon: "mail-check",
+            title: t(".no_invitations_title"),
+            description: t(".no_invitations_description")
+          ) %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <% if pagy.last > 1 %>

--- a/app/views/admin/settings/boards/index.html.erb
+++ b/app/views/admin/settings/boards/index.html.erb
@@ -60,13 +60,16 @@
       <% end %>
     <% else %>
       <%= render Elements::PanelComponent.new do |c| %>
-        <% c.with_body(class: "txt-align-center", style: "padding: var(--space-8);") do %>
-          <%= lucide_icon "folder", class: "center size-12 txt-subtle" %>
-        <h3 class="txt-large font-weight-semibold margin-block-start"><%= t(".no_boards_title") %></h3>
-        <p class="txt-small txt-subtle margin-block-start-half"><%= t(".no_boards_description") %></p>
-        <div style="margin-block-start: var(--space-6);">
-          <%= link_to t(".create_first_board"), new_admin_settings_board_path, class: "btn btn--primary" %>
-        </div>
+        <% c.with_body do %>
+          <%= render Elements::EmptyStateComponent.new(
+                icon: "folder",
+                title: t(".no_boards_title"),
+                description: t(".no_boards_description")
+              ) do |empty| %>
+            <% empty.with_cta do %>
+              <%= link_to t(".create_first_board"), new_admin_settings_board_path, class: "btn btn--primary" %>
+            <% end %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/admin/settings/statuses/index.html.erb
+++ b/app/views/admin/settings/statuses/index.html.erb
@@ -75,13 +75,16 @@
       <% end %>
     <% else %>
       <%= render Elements::PanelComponent.new do |c| %>
-        <% c.with_body(class: "txt-align-center", style: "padding: var(--space-8);") do %>
-          <%= lucide_icon "tag", class: "size-12 txt-subtle center" %>
-        <h3 class="txt-medium font-weight-bold margin-block-start"><%= t(".no_statuses_title") %></h3>
-        <p class="txt-small txt-subtle margin-block-start-half"><%= t(".no_statuses_description") %></p>
-        <div style="margin-block-start: var(--space-6);">
-          <%= link_to t(".create_first_status"), new_admin_settings_status_path, class: "btn btn--primary" %>
-        </div>
+        <% c.with_body do %>
+          <%= render Elements::EmptyStateComponent.new(
+                icon: "tag",
+                title: t(".no_statuses_title"),
+                description: t(".no_statuses_description")
+              ) do |empty| %>
+            <% empty.with_cta do %>
+              <%= link_to t(".create_first_status"), new_admin_settings_status_path, class: "btn btn--primary" %>
+            <% end %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/admin/settings/webhooks/index.html.erb
+++ b/app/views/admin/settings/webhooks/index.html.erb
@@ -26,13 +26,16 @@
       <% end %>
     <% else %>
       <%= render Elements::PanelComponent.new do |c| %>
-        <% c.with_body(class: "txt-align-center", style: "padding: var(--space-8);") do %>
-          <%= lucide_icon "webhook", class: "center size-12 txt-subtle" %>
-          <h3 class="txt-large font-weight-semibold margin-block-start"><%= t(".no_webhooks_title") %></h3>
-          <p class="txt-small txt-subtle margin-block-start-half"><%= t(".no_webhooks_description") %></p>
-          <div style="margin-block-start: var(--space-6);">
-            <%= link_to t(".new_webhook"), new_admin_settings_webhook_path, class: "btn btn--primary" %>
-          </div>
+        <% c.with_body do %>
+          <%= render Elements::EmptyStateComponent.new(
+                icon: "webhook",
+                title: t(".no_webhooks_title"),
+                description: t(".no_webhooks_description")
+              ) do |empty| %>
+            <% empty.with_cta do %>
+              <%= link_to t(".new_webhook"), new_admin_settings_webhook_path, class: "btn btn--primary" %>
+            <% end %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/admin/users/_users_list.html.erb
+++ b/app/views/admin/users/_users_list.html.erb
@@ -97,18 +97,13 @@
           <% end %>
         <% else %>
           <tr>
-            <td colspan="7" class="txt-align-center" style="padding-inline: var(--space-6); padding-block: var(--space-12);">
-              <div class="center size-12 fill-shade flex align-center justify-center" style="margin-block-end: var(--space-4); border-radius: 9999px;">
-                <%= lucide_icon "users", class: "size-6 txt-subtle" %>
-              </div>
-              <h3 class="txt-small font-weight-medium margin-block-end-half"><%= t(".no_users_title") %></h3>
-              <p class="txt-small txt-subtle">
-                <% if params[:search].present? %>
-                  <%= t(".no_users_search") %>
-                <% else %>
-                  <%= t(".no_users_empty") %>
-                <% end %>
-              </p>
+            <td colspan="7">
+              <%= render Elements::EmptyStateComponent.new(
+                    icon: "users",
+                    title: t(".no_users_title"),
+                    description: (params[:search].present? ? t(".no_users_search") : t(".no_users_empty")),
+                    variant: :compact
+                  ) %>
             </td>
           </tr>
         <% end %>

--- a/app/views/staff/accounts/_accounts_list.html.erb
+++ b/app/views/staff/accounts/_accounts_list.html.erb
@@ -49,18 +49,13 @@
           <% end %>
         <% else %>
           <tr>
-            <td colspan="4" class="txt-align-center" style="padding-inline: var(--space-6); padding-block: var(--space-12);">
-              <div class="center size-12 fill-shade flex align-center justify-center" style="margin-block-end: var(--space-4); border-radius: 9999px;">
-                <%= lucide_icon "building.svg", class: "size-6 txt-subtle" %>
-              </div>
-              <h3 class="txt-small font-weight-medium margin-block-end-half"><%= t(".no_accounts_found") %></h3>
-              <p class="txt-small txt-subtle">
-                <% if params[:search].present? %>
-                  <%= t(".try_adjusting_search") %>
-                <% else %>
-                  <%= t(".no_accounts_yet") %>
-                <% end %>
-              </p>
+            <td colspan="4">
+              <%= render Elements::EmptyStateComponent.new(
+                    icon: "building",
+                    title: t(".no_accounts_found"),
+                    description: (params[:search].present? ? t(".try_adjusting_search") : t(".no_accounts_yet")),
+                    variant: :compact
+                  ) %>
             </td>
           </tr>
         <% end %>

--- a/test/controllers/admin/ideas_controller_test.rb
+++ b/test/controllers/admin/ideas_controller_test.rb
@@ -44,5 +44,13 @@ module Admin
 
       assert_redirected_to sign_in_path
     end
+
+    test "index renders shared empty-state when no ideas exist" do
+      get admin_ideas_path, params: { search: "zzzz_no_match_zzzz" }
+
+      assert_response :success
+      assert_match(/empty-state__title/, @response.body)
+      assert_includes @response.body, I18n.t("admin.ideas.ideas_list.no_ideas_title")
+    end
   end
 end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -44,5 +44,13 @@ module Admin
 
       assert_redirected_to sign_in_path
     end
+
+    test "index renders shared empty-state when no users match the search" do
+      get admin_users_path, params: { search: "zzzz_no_match_zzzz" }
+
+      assert_response :success
+      assert_match(/empty-state__title/, @response.body)
+      assert_includes @response.body, I18n.t("admin.users.users_list.no_users_title")
+    end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized empty-state layouts across admin sections (changelogs, ideas, invitations, boards, statuses, webhooks, users, and accounts) for consistent visual presentation and improved user experience.

* **Tests**
  * Added integration tests verifying empty-state rendering when search queries return no results in admin ideas and users sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/murny/feedbackbin/pull/984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->